### PR TITLE
Remove tests with assertions on time

### DIFF
--- a/tests/Alchemy/Zippy/Functional/ListArchiveTest.php
+++ b/tests/Alchemy/Zippy/Functional/ListArchiveTest.php
@@ -21,9 +21,6 @@ class ListArchiveTest extends FunctionalTestCase
     {
         $target = __DIR__ . '/samples/tmp';
 
-        $expectedMembers = $archive->getMembers($target);
-        $foundMembers = array();
-
         $files2find = array(
             'directory/',
             'directory/README.md',
@@ -31,13 +28,11 @@ class ListArchiveTest extends FunctionalTestCase
         );
 
         foreach ($archive as $member) {
-            $foundMembers[] = $member;
             $this->assertInstanceOf('Alchemy\Zippy\Archive\MemberInterface', $member);
-            $this->assertTrue(in_array($member->getLocation(), $files2find));
+            $this->assertContains($member->getLocation(), $files2find);
             unset($files2find[array_search($member->getLocation(), $files2find)]);
         }
 
-        $this->assertEquals($expectedMembers, $foundMembers);
         $this->assertEquals(array(), $files2find);
     }
 


### PR DESCRIPTION
Because compressing files can takes several seconds, I removed assertions between DateTime properties to avoid failures.
