### PR TITLE
Fix strategy implementation

### DIFF
--- a/src/Alchemy/Zippy/FileStrategy/AbstractFileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/AbstractFileStrategy.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Zippy.
+ *
+ * (c) Alchemy <info@alchemy.fr>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Alchemy\Zippy\FileStrategy;
+
+use Alchemy\Zippy\Adapter\AdapterContainer;
+use Alchemy\Zippy\Exception\RuntimeException;
+
+abstract class AbstractFileStrategy implements FileStrategyInterface
+{
+    protected $container;
+
+    public function __construct(AdapterContainer $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAdapters()
+    {
+        $services = array();
+        foreach ($this->getServiceNames() as $serviceName) {
+            try {
+                $services[] = $this->container[$serviceName];
+            } catch (RuntimeException $e) {
+
+            }
+        }
+
+        return $services;
+    }
+
+    /**
+     * Returns an array of service names that defines adapters.
+     *
+     * @return string[]
+     */
+    abstract protected function getServiceNames();
+}

--- a/src/Alchemy/Zippy/FileStrategy/TB2FileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TB2FileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TB2FileStrategy implements FileStrategyInterface
+class TB2FileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/TBz2FileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TBz2FileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TBz2FileStrategy implements FileStrategyInterface
+class TBz2FileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/TGzFileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TGzFileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TGzFileStrategy implements FileStrategyInterface
+class TGzFileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/TarBz2FileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TarBz2FileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TarBz2FileStrategy implements FileStrategyInterface
+class TarBz2FileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/TarFileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TarFileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TarFileStrategy implements FileStrategyInterface
+class TarFileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarGNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarBSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/TarGzFileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/TarGzFileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class TarGzFileStrategy implements FileStrategyInterface
+class TarGzFileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'],
+            'Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter',
+            'Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'
         );
     }
 

--- a/src/Alchemy/Zippy/FileStrategy/ZipFileStrategy.php
+++ b/src/Alchemy/Zippy/FileStrategy/ZipFileStrategy.php
@@ -11,25 +11,16 @@
 
 namespace Alchemy\Zippy\FileStrategy;
 
-use Alchemy\Zippy\Adapter\AdapterContainer;
-
-class ZipFileStrategy implements FileStrategyInterface
+class ZipFileStrategy extends AbstractFileStrategy
 {
-    private $container;
-
-    public function __construct(AdapterContainer $container)
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
-    public function getAdapters()
+    protected function getServiceNames()
     {
         return array(
-            $this->container['Alchemy\\Zippy\\Adapter\\ZipAdapter'],
-            $this->container['Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'],
+            'Alchemy\\Zippy\\Adapter\\ZipAdapter',
+            'Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'
         );
     }
 

--- a/tests/Alchemy/Zippy/Tests/FileStrategy/AbstractFileStrategyTest.php
+++ b/tests/Alchemy/Zippy/Tests/FileStrategy/AbstractFileStrategyTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Alchemy\Zippy\Tests\FileStrategy;
+
+use Alchemy\Zippy\Adapter\AdapterContainer;
+use Alchemy\Zippy\Tests\TestCase;
+use Alchemy\Zippy\Exception\RuntimeException;
+
+class AbstractFileStrategyTest extends TestCase
+{
+    /**
+     * @expectedException   \InvalidArgumentException
+     */
+    public function testGetAdaptersWithNoDefinedServices()
+    {
+        $container = AdapterContainer::load();
+
+        $stub = $this->getMockForAbstractClass('Alchemy\Zippy\FileStrategy\AbstractFileStrategy', array($container));
+        $stub->expects($this->any())
+            ->method('getServiceNames')
+            ->will($this->returnValue(array(
+                'Unknown\Services'
+            )));
+
+
+        $adapters = $stub->getAdapters();
+        $this->assertInternalType('array', $adapters);
+        $this->assertCount(0, $adapters);
+    }
+
+    public function testGetAdapters()
+    {
+        $container = AdapterContainer::load();
+
+        $stub = $this->getMockForAbstractClass('Alchemy\Zippy\FileStrategy\AbstractFileStrategy', array($container));
+        $stub->expects($this->any())
+            ->method('getServiceNames')
+            ->will($this->returnValue(array(
+                'Alchemy\\Zippy\\Adapter\\ZipAdapter',
+                'Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'
+            )));
+
+        $adapters = $stub->getAdapters();
+        $this->assertInternalType('array', $adapters);
+        $this->assertCount(2, $adapters);
+        foreach ($adapters as $adapter) {
+            $this->assertInstanceOf('Alchemy\\Zippy\\Adapter\\AdapterInterface', $adapter);
+        }
+    }
+
+    public function testGetAdaptersWithAdapterThatRaiseAnException()
+    {
+        $adapterMock = $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $container
+            ->expects($this->at(0))
+            ->method('offsetGet')
+            ->with($this->equalTo('Alchemy\\Zippy\\Adapter\\ZipAdapter'))
+            ->will($this->returnValue($adapterMock));
+
+        $container
+            ->expects($this->at(1))
+            ->method('offsetGet')
+            ->with($this->equalTo('Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'))
+            ->will($this->throwException(new RuntimeException()));
+
+        $stub = $this->getMockForAbstractClass('Alchemy\Zippy\FileStrategy\AbstractFileStrategy', array($container));
+        $stub->expects($this->any())
+            ->method('getServiceNames')
+            ->will($this->returnValue(array(
+                'Alchemy\\Zippy\\Adapter\\ZipAdapter',
+                'Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'
+            )));
+
+        $adapters = $stub->getAdapters();
+        $this->assertInternalType('array', $adapters);
+        $this->assertCount(1, $adapters);
+        foreach ($adapters as $adapter) {
+            $this->assertSame($adapterMock, $adapter);
+        }
+    }   
+}

--- a/tests/Alchemy/Zippy/Tests/FileStrategy/FileStrategyTestCase.php
+++ b/tests/Alchemy/Zippy/Tests/FileStrategy/FileStrategyTestCase.php
@@ -3,6 +3,7 @@
 namespace Alchemy\Zippy\Tests\FileStrategy;
 
 use Alchemy\Zippy\Adapter\AdapterInterface;
+use Alchemy\Zippy\Exception\RuntimeException;
 use Alchemy\Zippy\Tests\TestCase;
 use Alchemy\Zippy\FileStrategy\FileStrategyInterface;
 
@@ -45,6 +46,24 @@ abstract class FileStrategyTestCase extends TestCase
 
                     return null;
                 }));
+
+        $adapters = $this->getStrategy($container)->getAdapters();
+
+        $this->assertInternalType('array', $adapters);
+
+        foreach ($adapters as $adapter) {
+            $this->assertInstanceOf('Alchemy\\Zippy\\Adapter\\AdapterInterface', $adapter);
+        }
+    }
+
+    /** @test */
+    public function getAdaptersShouldReturnAnArrayOfAdapterEvenIfAdapterRaiseAnException()
+    {
+        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $container
+            ->expects($this->any())
+            ->method('offsetGet')
+            ->will($this->throwException(new RuntimeException()));
 
         $adapters = $this->getStrategy($container)->getAdapters();
 


### PR DESCRIPTION
I've recently experienced some issues with adapter strategy due to the following commit
https://github.com/alchemy-fr/Zippy/commit/d4b656bab21e46cd09a34cd981712cf1f08138d8 as it introduced exception in binary adapter constructor. 
When we test test the different strategies and one of the inflator or deflator binaries is not found, the exception is raised but never catched so the following defined strategies could not be runned.
