### PR TITLE
Move guzzle to suggestions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "require": {
         "php"                  : ">=5.3.3",
         "doctrine/collections" : "~1.0",
-        "guzzle/guzzle"        : "~3.0",
         "pimple/pimple"        : "~1.0",
         "symfony/process"      : "~2.0",
         "symfony/filesystem"   : "~2.0"
@@ -23,10 +22,11 @@
         "ext-zip"              : "*",
         "phpunit/phpunit"      : "~3.7",
         "symfony/finder"       : "~2.0",
-        "sami/sami"            : "dev-master@dev"
+        "sami/sami"            : "~1.0"
     },
     "suggest": {
-        "ext-zip"              : "To use the ZipExtensionAdapter"
+        "ext-zip"              : "To use the ZipExtensionAdapter",
+        "guzzle/guzzle"        : "To use the GuzzleTeleporter"
     },
     "autoload": {
         "psr-0": {

--- a/src/Alchemy/Zippy/Resource/TeleporterContainer.php
+++ b/src/Alchemy/Zippy/Resource/TeleporterContainer.php
@@ -70,9 +70,13 @@ class TeleporterContainer extends \Pimple
         $container['local-teleporter'] = $container->share(function () {
             return LocalTeleporter::create();
         });
-        $container['guzzle-teleporter'] = $container->share(function () {
-            return GuzzleTeleporter::create();
-        });
+        if (class_exists('Guzzle\Http\Client')) {
+            $container['guzzle-teleporter'] = $container->share(
+                function () {
+                    return GuzzleTeleporter::create();
+                }
+            );
+        }
 
         return $container;
     }

--- a/tests/Alchemy/Zippy/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
+++ b/tests/Alchemy/Zippy/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
@@ -13,6 +13,10 @@ class GuzzleTeleporterTest extends TeleporterTestCase
      */
     public function testTeleport($context)
     {
+        if (false === class_exists('Guzzle\Http\Client')) {
+            $this->markTestSkipped('Guzzle library is not installed');
+        }
+
         $teleporter = GuzzleTeleporter::create();
 
         $target = 'plop-badge.png';
@@ -33,6 +37,10 @@ class GuzzleTeleporterTest extends TeleporterTestCase
      */
     public function testCreate()
     {
+        if (false === class_exists('Guzzle\Http\Client')) {
+            $this->markTestSkipped('Guzzle library is not installed');
+        }
+
         $this->assertInstanceOf('Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter', GuzzleTeleporter::create());
     }
 }


### PR DESCRIPTION
We don't always use GuzzleTeleporter. Also if you have installed a new version of Guzzle, this will conflict with the version installed with this library.