### PR TITLE
Add static member on ZipOutputParser to specify custom date formats

### DIFF
--- a/src/Parser/ParserFactory.php
+++ b/src/Parser/ParserFactory.php
@@ -15,6 +15,17 @@ use Alchemy\Zippy\Exception\InvalidArgumentException;
 
 class ParserFactory
 {
+
+    private static $zipDateFormat = 'Y-m-d H:i';
+
+    /**
+     * @param string $format Date format used to parse ZIP file listings
+     */
+    public static function setZipDateFormat($format)
+    {
+        self::$zipDateFormat = $format;
+    }
+
     /**
      * Maps the corresponding parser to the selected adapter
      *
@@ -34,7 +45,7 @@ class ParserFactory
                 return new BSDTarOutputParser();
                 break;
             case 'zip':
-                return new ZipOutputParser();
+                return new ZipOutputParser(self::$zipDateFormat);
                 break;
 
             default:

--- a/src/Parser/ZipOutputParser.php
+++ b/src/Parser/ZipOutputParser.php
@@ -20,6 +20,19 @@ class ZipOutputParser implements ParserInterface
     const FILENAME      = "(.*)";
 
     /**
+     * @var string
+     */
+    private $dateFormat;
+
+    /**
+     * @param string $dateFormat
+     */
+    public function __construct($dateFormat = "Y-m-d H:i")
+    {
+        $this->dateFormat = $dateFormat;
+    }
+
+    /**
      * @inheritdoc
      */
     public function parseFileListing($output)
@@ -50,7 +63,7 @@ class ZipOutputParser implements ParserInterface
             $members[] = array(
                 'location'  => $chunks[3],
                 'size'      => $chunks[1],
-                'mtime'     => \DateTime::createFromFormat("Y-m-d H:i", $chunks[2]),
+                'mtime'     => \DateTime::createFromFormat($this->dateFormat, $chunks[2]),
                 'is_dir'    => '/' === substr($chunks[3], -1)
             );
         }

--- a/tests/Tests/Parser/ZipOutputParserTest.php
+++ b/tests/Tests/Parser/ZipOutputParserTest.php
@@ -12,21 +12,37 @@ class ZipOutputParserTest extends TestCase
         return new ZipOutputParser();
     }
 
-    /**
-     * @depends testNewParser
-     */
-    public function testParseFileListing($parser)
+    public function getDatasets()
     {
-        $current_timezone = ini_get('date.timezone');
-        ini_set('date.timezone', 'UTC');
-
-        $output =
-"Length   Date     Time     Name
+        $standardOutput =
+            "Length   Date     Time     Name
 -------- ----     ----     ----
      0   2006-06-09 12:06  practice/
  10240   2006-06-09 12:06  practice/records
 --------                    -------
     785                      2 files";
+
+        $altOutput =
+            "Length   Date     Time     Name
+-------- ----     ----     ----
+     0   09-06-06 12:06  practice/
+ 10240   09-06-06 12:06  practice/records
+--------                    -------
+    785                      2 files";
+
+        return array(
+            array(new ZipOutputParser(), $standardOutput),
+            array(new ZipOutputParser('d-m-y H:i'), $altOutput)
+        );
+    }
+
+    /**
+     * @dataProvider getDatasets
+     */
+    public function testParseFileListing($parser, $output)
+    {
+        $current_timezone = ini_get('date.timezone');
+        ini_set('date.timezone', 'UTC');
 
         $members = $parser->parseFileListing($output);
 


### PR DESCRIPTION
Fixes #86 

Allows to specify an arbitrary date format to parse ZIP file listings by calling:

```php
Alchemy\Zippy\Parser\ParserFactory::setZipDateFormat('d-m-y');
```