### PR TITLE
Add optional argument to overwrite target file

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -13,6 +13,7 @@
 namespace Alchemy\Zippy\Adapter;
 
 use Alchemy\Zippy\Archive\Archive;
+use Alchemy\Zippy\Archive\ArchiveInterface;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Resource\ResourceManager;
 use Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface;
@@ -99,11 +100,11 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * @inheritdoc
      */
-    public function extractMembers(ResourceInterface $resource, $members, $to = null)
+    public function extractMembers(ResourceInterface $resource, $members, $to = null, $overwrite = false)
     {
         $this->requireSupport();
 
-        return $this->doExtractMembers($resource, $members, $to);
+        return $this->doExtractMembers($resource, $members, $to, $overwrite);
     }
 
     /**
@@ -203,9 +204,13 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Do the extract members after having check that the current adapter is supported
      *
+     * @param ResourceInterface $resource
+     * @param string|string[] $members
+     * @param string $to
+     * @param bool $overwrite
      * @return \SplFileInfo The extracted archive
      */
-    abstract protected function doExtractMembers(ResourceInterface $resource, $members, $to);
+    abstract protected function doExtractMembers(ResourceInterface $resource, $members, $to, $overwrite = false);
 
     /**
      * Do the list members after having check that the current adapter is supported

--- a/src/Adapter/AbstractBinaryAdapter.php
+++ b/src/Adapter/AbstractBinaryAdapter.php
@@ -16,10 +16,10 @@ use Alchemy\Zippy\Adapter\Resource\FileResource;
 use Alchemy\Zippy\Archive\MemberInterface;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\RuntimeException;
-use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\Parser\ParserFactory;
-use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
+use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory;
+use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
 use Alchemy\Zippy\Resource\ResourceManager;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
@@ -50,13 +50,17 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
     /**
      * Constructor
      *
-     * @param ParserInterface                     $parser   An output parser
-     * @param ResourceManager                     $manager  A resource manager
-     * @param ProcessBuilderFactoryInterface      $inflator A process builder factory for the inflator binary
+     * @param ParserInterface $parser An output parser
+     * @param ResourceManager $manager A resource manager
+     * @param ProcessBuilderFactoryInterface $inflator A process builder factory for the inflator binary
      * @param ProcessBuilderFactoryInterface|null $deflator A process builder factory for the deflator binary
      */
-    public function __construct(ParserInterface $parser, ResourceManager $manager, ProcessBuilderFactoryInterface $inflator, ProcessBuilderFactoryInterface $deflator)
-    {
+    public function __construct(
+        ParserInterface $parser,
+        ResourceManager $manager,
+        ProcessBuilderFactoryInterface $inflator,
+        ProcessBuilderFactoryInterface $deflator
+    ) {
         $this->parser = $parser;
         $this->manager = $manager;
         $this->deflator = $deflator;
@@ -144,10 +148,16 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
      *
      * @throws RuntimeException In case object could not be instanciated
      */
-    public static function newInstance(ExecutableFinder $finder, ResourceManager $manager, $inflatorBinaryName = null, $deflatorBinaryName = null)
-    {
-        $inflator = $inflatorBinaryName instanceof ProcessBuilderFactoryInterface ? $inflatorBinaryName : self::findABinary($inflatorBinaryName, static::getDefaultInflatorBinaryName(), $finder);
-        $deflator = $deflatorBinaryName instanceof ProcessBuilderFactoryInterface ? $deflatorBinaryName : self::findABinary($deflatorBinaryName, static::getDefaultDeflatorBinaryName(), $finder);
+    public static function newInstance(
+        ExecutableFinder $finder,
+        ResourceManager $manager,
+        $inflatorBinaryName = null,
+        $deflatorBinaryName = null
+    ) {
+        $inflator = $inflatorBinaryName instanceof ProcessBuilderFactoryInterface ? $inflatorBinaryName : self::findABinary($inflatorBinaryName,
+            static::getDefaultInflatorBinaryName(), $finder);
+        $deflator = $deflatorBinaryName instanceof ProcessBuilderFactoryInterface ? $deflatorBinaryName : self::findABinary($deflatorBinaryName,
+            static::getDefaultDeflatorBinaryName(), $finder);
 
         try {
             $outputParser = ParserFactory::create(static::getName());
@@ -171,7 +181,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
 
     private static function findABinary($wish, array $defaults, ExecutableFinder $finder)
     {
-        $possibles = $wish ? (array) $wish : $defaults;
+        $possibles = $wish ? (array)$wish : $defaults;
 
         $binary = null;
 
@@ -188,7 +198,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
     /**
      * Adds files to argument list
      *
-     * @param Array          $files   An array of files
+     * @param Array $files An array of files
      * @param ProcessBuilder $builder A Builder instance
      *
      * @return Boolean
@@ -200,8 +210,8 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
         array_walk($files, function ($file) use ($builder, &$iterations) {
             $builder->add(
                 $file instanceof \SplFileInfo ?
-                $file->getRealpath() :
-                ($file instanceof MemberInterface ? $file->getLocation() : $file)
+                    $file->getRealpath() :
+                    ($file instanceof MemberInterface ? $file->getLocation() : $file)
             );
 
             $iterations++;

--- a/src/Adapter/AbstractTarAdapter.php
+++ b/src/Adapter/AbstractTarAdapter.php
@@ -56,9 +56,9 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     /**
      * @inheritdoc
      */
-    protected function doExtractMembers(ResourceInterface $resource, $members, $to)
+    protected function doExtractMembers(ResourceInterface $resource, $members, $to, $overwrite = false)
     {
-        return $this->doTarExtractMembers($this->getLocalOptions(), $resource, $members, $to);
+        return $this->doTarExtractMembers($this->getLocalOptions(), $resource, $members, $to, $overwrite);
     }
 
     /**
@@ -345,7 +345,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
         return new \SplFileInfo($to ? : $resource->getResource());
     }
 
-    protected function doTarExtractMembers($options, ResourceInterface $resource, $members, $to = null)
+    protected function doTarExtractMembers($options, ResourceInterface $resource, $members, $to = null, $overwrite = false)
     {
         if (null !== $to && !is_dir($to)) {
             throw new InvalidArgumentException(sprintf("%s is not a directory", $to));
@@ -356,6 +356,10 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
         $builder = $this
             ->inflator
             ->create();
+
+        if ($overwrite == false) {
+            $builder->add('-k');
+        }
 
         $builder
             ->add('--extract')

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -11,9 +11,11 @@
 
 namespace Alchemy\Zippy\Adapter;
 
-use Alchemy\Zippy\Archive\ArchiveInterface;
 use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Archive\ArchiveInterface;
+use Alchemy\Zippy\Archive\MemberInterface;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Exception\NotSupportedException;
 use Alchemy\Zippy\Exception\RuntimeException;
 
 Interface AdapterInterface
@@ -21,12 +23,12 @@ Interface AdapterInterface
     /**
      * Opens an archive
      *
-     * @param String $path The path to the archive
+     * @param string $path The path to the archive
      *
      * @return ArchiveInterface
      *
      * @throws InvalidArgumentException In case the provided path is not valid
-     * @throws RuntimeException         In case of failure
+     * @throws RuntimeException In case of failure
      */
     public function open($path);
 
@@ -36,14 +38,14 @@ Interface AdapterInterface
      * Please note some adapters can not create empty archives.
      * They would throw a `NotSupportedException` in case you ask to create an archive without files
      *
-     * @param String                         $path      The path to the archive
-     * @param String|Array|\Traversable|null $files     A filename, an array of files, or a \Traversable instance
-     * @param Boolean                        $recursive Whether to recurse or not in the provided directories
+     * @param string $path The path to the archive
+     * @param string|string[]|\Traversable|null $files A filename, an array of files, or a \Traversable instance
+     * @param bool $recursive Whether to recurse or not in the provided directories
      *
      * @return ArchiveInterface
      *
-     * @throws RuntimeException         In case of failure
-     * @throws NotSupportedException    In case the operation in not supported
+     * @throws RuntimeException In case of failure
+     * @throws NotSupportedException In case the operation in not supported
      * @throws InvalidArgumentException In case no files could be added
      */
     public function create($path, $files = null, $recursive = true);
@@ -51,7 +53,7 @@ Interface AdapterInterface
     /**
      * Tests if the adapter is supported by the current environment
      *
-     * @return Boolean
+     * @return bool
      */
     public function isSupported();
 
@@ -60,7 +62,7 @@ Interface AdapterInterface
      *
      * @param ResourceInterface $resource The path to the archive
      *
-     * @return Array
+     * @return array
      *
      * @throws RuntimeException In case of failure
      */
@@ -69,13 +71,13 @@ Interface AdapterInterface
     /**
      * Adds a file to the archive
      *
-     * @param ResourceInterface         $resource  The path to the archive
-     * @param String|Array|\Traversable $files     An array of paths to add, relative to cwd
-     * @param Boolean                   $recursive Whether or not to recurse in the provided directories
+     * @param ResourceInterface $resource The path to the archive
+     * @param string|array|\Traversable $files An array of paths to add, relative to cwd
+     * @param bool $recursive Whether or not to recurse in the provided directories
      *
-     * @return Array
+     * @return array
      *
-     * @throws RuntimeException         In case of failure
+     * @throws RuntimeException In case of failure
      * @throws InvalidArgumentException In case no files could be added
      */
     public function add(ResourceInterface $resource, $files, $recursive = true);
@@ -83,12 +85,12 @@ Interface AdapterInterface
     /**
      * Removes a member of the archive
      *
-     * @param ResourceInterface         $resource The path to the archive
-     * @param String|Array|\Traversable $files    A filename, an array of files, or a \Traversable instance
+     * @param ResourceInterface $resource The path to the archive
+     * @param String|Array|\Traversable $files A filename, an array of files, or a \Traversable instance
      *
      * @return Array
      *
-     * @throws RuntimeException         In case of failure
+     * @throws RuntimeException In case of failure
      * @throws InvalidArgumentException In case no files could be removed
      */
     public function remove(ResourceInterface $resource, $files);
@@ -99,11 +101,11 @@ Interface AdapterInterface
      * Note that any existing files will be overwritten by the adapter
      *
      * @param ResourceInterface $resource The path to the archive
-     * @param String|null       $to       The path where to extract the archive
+     * @param string|null $to The path where to extract the archive
      *
      * @return \SplFileInfo The extracted archive
      *
-     * @throws RuntimeException         In case of failure
+     * @throws RuntimeException In case of failure
      * @throws InvalidArgumentException In case the provided path where to extract the archive is not valid
      */
     public function extract(ResourceInterface $resource, $to = null);
@@ -112,15 +114,16 @@ Interface AdapterInterface
      * Extracts specific members of the archive
      *
      * @param ResourceInterface $resource The path to the archive
-     * @param Array             $members  An array of members
-     * @param String|null       $to       The path where to extract the members
+     * @param string|string[] $members A path or array of paths matching the members to extract from the resource.
+     * @param string|null $to The path where to extract the members
+     * @param bool $overwrite Whether to overwrite existing files in target directory
      *
      * @return \SplFileInfo The extracted archive
      *
-     * @throws RuntimeException         In case of failure
-     * @throws InvalidArgumentException In case no members could be removed or provide extract target directory is not valid
+     * @throws RuntimeException In case of failure
+     * @throws InvalidArgumentException In case no members could be removed or providedd extract target directory is not valid
      */
-    public function extractMembers(ResourceInterface $resource, $members, $to = null);
+    public function extractMembers(ResourceInterface $resource, $members, $to = null, $overwrite = false);
 
     /**
      * Returns the adapter name

--- a/src/Adapter/ZipAdapter.php
+++ b/src/Adapter/ZipAdapter.php
@@ -11,17 +11,17 @@
 
 namespace Alchemy\Zippy\Adapter;
 
+use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Adapter\VersionProbe\ZipVersionProbe;
 use Alchemy\Zippy\Archive\Archive;
 use Alchemy\Zippy\Archive\Member;
-use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
-use Alchemy\Zippy\Exception\RuntimeException;
-use Alchemy\Zippy\Exception\NotSupportedException;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Alchemy\Zippy\Resource\Resource;
-use Alchemy\Zippy\Resource\ResourceManager;
-use Alchemy\Zippy\Adapter\VersionProbe\ZipVersionProbe;
+use Alchemy\Zippy\Exception\NotSupportedException;
+use Alchemy\Zippy\Exception\RuntimeException;
 use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceManager;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 
 /**
@@ -31,9 +31,14 @@ use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
  */
 class ZipAdapter extends AbstractBinaryAdapter
 {
-    public function __construct(ParserInterface $parser, ResourceManager $manager, ProcessBuilderFactoryInterface $inflator, ProcessBuilderFactoryInterface $deflator)
-    {
+    public function __construct(
+        ParserInterface $parser,
+        ResourceManager $manager,
+        ProcessBuilderFactoryInterface $inflator,
+        ProcessBuilderFactoryInterface $deflator
+    ) {
         parent::__construct($parser, $manager, $inflator, $deflator);
+
         $this->probe = new ZipVersionProbe($inflator, $deflator);
     }
 
@@ -42,7 +47,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doCreate($path, $files, $recursive)
     {
-        $files = (array) $files;
+        $files = (array)$files;
 
         $builder = $this
             ->inflator
@@ -130,7 +135,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doAdd(ResourceInterface $resource, $files, $recursive)
     {
-        $files = (array) $files;
+        $files = (array)$files;
 
         $builder = $this
             ->inflator
@@ -225,7 +230,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doRemove(ResourceInterface $resource, $files)
     {
-        $files = (array) $files;
+        $files = (array)$files;
 
         $builder = $this
             ->inflator
@@ -319,17 +324,21 @@ class ZipAdapter extends AbstractBinaryAdapter
     /**
      * @inheritdoc
      */
-    protected function doExtractMembers(ResourceInterface $resource, $members, $to)
+    protected function doExtractMembers(ResourceInterface $resource, $members, $to, $overwrite = false)
     {
         if (null !== $to && !is_dir($to)) {
             throw new InvalidArgumentException(sprintf("%s is not a directory", $to));
         }
 
-        $members = (array) $members;
+        $members = (array)$members;
 
         $builder = $this
             ->deflator
             ->create();
+
+        if ((bool) $overwrite) {
+            $builder->add('-o');
+        }
 
         $builder
             ->add($resource->getResource());

--- a/src/Archive/Member.php
+++ b/src/Archive/Member.php
@@ -22,21 +22,21 @@ class Member implements MemberInterface
     /**
      * The location of the file
      *
-     * @var String
+     * @var string
      */
     private $location;
 
     /**
      * Tells whether the archive member is a directory or not
      *
-     * @var Boolean
+     * @var bool
      */
     private $isDir;
 
     /**
      * The uncompressed size of the file
      *
-     * @var Integer
+     * @var int
      */
     private $size;
 
@@ -50,7 +50,7 @@ class Member implements MemberInterface
     /**
      * The resource to the actual archive
      *
-     * @var String
+     * @var string
      */
     private $resource;
 
@@ -64,15 +64,21 @@ class Member implements MemberInterface
     /**
      * Constructor
      *
-     * @param ResourceInterface $resource         The path of the archive which contain the member
-     * @param AdapterInterface  $adapter          The archive adapter interface
-     * @param String            $location         The path of the archive member
-     * @param Integer           $fileSize         The uncompressed file size
-     * @param \DateTime         $lastModifiedDate The last modified date of the member
-     * @param Boolean           $isDir            Tells whether the member is a directory or not
+     * @param ResourceInterface $resource The path of the archive which contain the member
+     * @param AdapterInterface $adapter The archive adapter interface
+     * @param string $location The path of the archive member
+     * @param int $fileSize The uncompressed file size
+     * @param \DateTime $lastModifiedDate The last modified date of the member
+     * @param bool $isDir Tells whether the member is a directory or not
      */
-    public function __construct(ResourceInterface $resource, AdapterInterface $adapter, $location, $fileSize, \DateTime $lastModifiedDate, $isDir)
-    {
+    public function __construct(
+        ResourceInterface $resource,
+        AdapterInterface $adapter,
+        $location,
+        $fileSize,
+        \DateTime $lastModifiedDate,
+        $isDir
+    ) {
         $this->resource = $resource;
         $this->adapter = $adapter;
         $this->location = $location;
@@ -82,7 +88,7 @@ class Member implements MemberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getLocation()
     {
@@ -90,7 +96,7 @@ class Member implements MemberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function isDir()
     {
@@ -98,7 +104,7 @@ class Member implements MemberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getLastModifiedDate()
     {
@@ -106,7 +112,7 @@ class Member implements MemberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getSize()
     {
@@ -114,7 +120,7 @@ class Member implements MemberInterface
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function __toString()
     {
@@ -124,9 +130,9 @@ class Member implements MemberInterface
     /**
      * {@inheritdoc}
      */
-    public function extract($to = null)
+    public function extract($to = null, $overwrite = false)
     {
-        $this->adapter->extractMembers($this->resource, $this->location, $to);
+        $this->adapter->extractMembers($this->resource, $this->location, $to, (bool)$overwrite);
 
         return new \SplFileInfo(sprintf('%s%s', rtrim(null === $to ? getcwd() : $to, '/'), $this->location));
     }

--- a/src/Archive/MemberInterface.php
+++ b/src/Archive/MemberInterface.php
@@ -11,6 +11,9 @@
 
 namespace Alchemy\Zippy\Archive;
 
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Exception\RuntimeException;
+
 interface MemberInterface
 {
     /**
@@ -27,7 +30,7 @@ interface MemberInterface
      */
     public function isDir();
 
-    /*
+    /**
      * Returns the last modified date of the member
      *
      * @return \DateTime
@@ -50,14 +53,15 @@ interface MemberInterface
      * This will execute one extraction process for each file
      * Prefer the use of ArchiveInterface::extractMembers in that use case
      *
-     * @param String|null $to The path where to extract the member, if no path is not provided the member is extracted in the same directory of its archive
+     * @param string|null $to The path where to extract the member, if no path is not provided the member is extracted in the same directory of its archive
+     * @param bool $overwrite Whether to overwrite destination file if it already exists. Defaults to false
      *
      * @return \SplFileInfo The extracted file
      *
-     * @throws RuntimeException         In case of failure
+     * @throws RuntimeException In case of failure
      * @throws InvalidArgumentException In case no members could be removed or provide extract target directory is not valid
      */
-    public function extract($to = null);
+    public function extract($to = null, $overwrite = false);
 
     /**
      * @inheritdoc

--- a/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
@@ -306,35 +306,41 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(0))
             ->method('add')
-            ->with($this->equalTo('--extract'))
+            ->with($this->equalTo('-k'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(1))
             ->method('add')
-            ->with($this->equalTo('--file=' . $resource->getResource()))
+            ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo($this->getOptions()))
+            ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo('--directory'))
+            ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
             ->method('add')
-            ->with($this->equalTo(__DIR__))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(5))
+            ->method('add')
+            ->with($this->equalTo(__DIR__))
+            ->will($this->returnSelf());
+
+        $mockedProcessBuilder
+            ->expects($this->at(6))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());

--- a/tests/Tests/Adapter/BSDTar/TarBSDTarAdapterTest.php
+++ b/tests/Tests/Adapter/BSDTar/TarBSDTarAdapterTest.php
@@ -286,29 +286,35 @@ class TarBSDTarAdapterTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(0))
             ->method('add')
-            ->with($this->equalTo('--extract'))
+            ->with($this->equalTo('-k'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(1))
             ->method('add')
-            ->with($this->equalTo('--file=' . $resource->getResource()))
+            ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo('--directory'))
+            ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo(__DIR__))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
+            ->method('add')
+            ->with($this->equalTo(__DIR__))
+            ->will($this->returnSelf());
+
+        $mockedProcessBuilder
+            ->expects($this->at(5))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());

--- a/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
@@ -301,47 +301,53 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(0))
             ->method('add')
-            ->with($this->equalTo('--extract'))
+            ->with($this->equalTo('-k'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(1))
             ->method('add')
-            ->with($this->equalTo('--file=' . $resource->getResource()))
+            ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
+            ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo('--overwrite'))
+            ->with($this->equalTo('--overwrite-dir'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
             ->method('add')
-            ->with($this->equalTo($this->getOptions()))
+            ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(5))
             ->method('add')
-            ->with($this->equalTo('--directory'))
+            ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(6))
             ->method('add')
-            ->with($this->equalTo(__DIR__))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(7))
+            ->method('add')
+            ->with($this->equalTo(__DIR__))
+            ->will($this->returnSelf());
+
+        $mockedProcessBuilder
+            ->expects($this->at(8))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());

--- a/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
+++ b/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
@@ -300,41 +300,47 @@ class TarGNUTarAdapterTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(0))
             ->method('add')
-            ->with($this->equalTo('--extract'))
+            ->with($this->equalTo('-k'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(1))
             ->method('add')
-            ->with($this->equalTo('--file=' . $resource->getResource()))
+            ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
+            ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo('--overwrite'))
+            ->with($this->equalTo('--overwrite-dir'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
             ->method('add')
-            ->with($this->equalTo('--directory'))
+            ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(5))
             ->method('add')
-            ->with($this->equalTo(__DIR__))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(6))
+            ->method('add')
+            ->with($this->equalTo(__DIR__))
+            ->will($this->returnSelf());
+
+        $mockedProcessBuilder
+            ->expects($this->at(7))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());

--- a/tests/Tests/Adapter/ZipExtensionAdapterTest.php
+++ b/tests/Tests/Adapter/ZipExtensionAdapterTest.php
@@ -7,6 +7,9 @@ use Alchemy\Zippy\Adapter\Resource\ZipArchiveResource;
 
 class ZipExtensionAdapterTest extends AdapterTestCase
 {
+    /**
+     * @var ZipExtensionAdapter
+     */
     private $adapter;
 
     public function setUp()
@@ -38,7 +41,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\NotSupportedException
+     * @expectedException \Alchemy\Zippy\Exception\NotSupportedException
      */
     public function testCreateNoFiles()
     {
@@ -58,7 +61,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
      */
     public function testOpenWithWrongFileName()
     {
@@ -106,7 +109,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testExtractOnError()
     {
@@ -123,7 +126,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testExtractWithInvalidTarget()
     {
@@ -135,7 +138,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testExtractWithInvalidTarget2()
     {
@@ -169,7 +172,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testRemoveWithLocateFailing()
     {
@@ -190,7 +193,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
      */
     public function testRemoveWithDeleteFailing()
     {
@@ -248,7 +251,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
      */
     public function testAddFailOnFile()
     {
@@ -277,7 +280,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
      */
     public function testAddFailOnDir()
     {


### PR DESCRIPTION
Fixes #96 by adding an optional argument to allow overwriting of target files when calling extract() on an archive member.