### PR TITLE
Require mbstring extension to be available

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
+        "ext-mbstring": "*",
         "doctrine/collections": "~1.0",
         "symfony/filesystem": "^2.0.5|^3.0",
         "symfony/process": "^2.1|^3.0"


### PR DESCRIPTION
Fixes #98 by adding the mbstring extension as a platform requirement in composer.json