### PR TITLE
Refactor teleporters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ language: php
 sudo: required
 
 php:
-  - 5.3.3
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -15,13 +13,13 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.3.3
+    - php: 5.5
       env: PREFER_LOWEST="--prefer-lowest"
 
 before_script:
   - sudo apt-get install bsdtar zip
   - npm install connect serve-static
-  - composer update --prefer-source --no-interaction $PREFER_LOWEST
+  - composer update --no-interaction $PREFER_LOWEST
   - if [ -n "$PREFER_LOWEST" ];then composer update phpunit/phpunit --prefer-source --no-interaction --with-dependencies;fi
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.5",
         "ext-mbstring": "*",
         "doctrine/collections": "~1.0",
         "symfony/filesystem": "^2.0.5|^3.0",
@@ -21,13 +21,14 @@
     "require-dev": {
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
+        "guzzlehttp/guzzle": "^6.0",
         "phpunit/phpunit": "^4.0|^5.0",
-        "symfony/finder": "^2.0.5|^3.0",
-        "guzzlehttp/guzzle": "^6.1"
+        "symfony/finder": "^2.0.5|^3.0"
     },
     "suggest": {
         "ext-zip": "To use the ZipExtensionAdapter",
-        "guzzle/guzzle": "To use the GuzzleTeleporter"
+        "guzzlehttp/guzzle": "To use the GuzzleTeleporter with Guzzle 6",
+        "guzzle/guzzle": "To use the GuzzleTeleporter with Guzzle 3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
         "phpunit/phpunit": "^4.0|^5.0",
-        "symfony/finder": "^2.0.5|^3.0"
+        "symfony/finder": "^2.0.5|^3.0",
+        "guzzlehttp/guzzle": "^6.1"
     },
     "suggest": {
         "ext-zip": "To use the ZipExtensionAdapter",

--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -247,6 +247,6 @@ abstract class AbstractAdapter implements AdapterInterface
             throw new InvalidArgumentException(sprintf('Target path %s is not writeable.', $directory));
         }
 
-        return realpath($directory).'/'.PathUtil::basename($path);
+        return realpath($directory) . '/' . PathUtil::basename($path);
     }
 }

--- a/src/Adapter/AbstractBinaryAdapter.php
+++ b/src/Adapter/AbstractBinaryAdapter.php
@@ -53,7 +53,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
      * @param ParserInterface $parser An output parser
      * @param ResourceManager $manager A resource manager
      * @param ProcessBuilderFactoryInterface $inflator A process builder factory for the inflator binary
-     * @param ProcessBuilderFactoryInterface|null $deflator A process builder factory for the deflator binary
+     * @param ProcessBuilderFactoryInterface $deflator A process builder factory for the deflator binary
      */
     public function __construct(
         ParserInterface $parser,
@@ -181,7 +181,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
 
     private static function findABinary($wish, array $defaults, ExecutableFinder $finder)
     {
-        $possibles = $wish ? (array)$wish : $defaults;
+        $possibles = $wish ? (array) $wish : $defaults;
 
         $binary = null;
 
@@ -207,11 +207,10 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
     {
         $iterations = 0;
 
-        array_walk($files, function ($file) use ($builder, &$iterations) {
+        array_walk($files, function($file) use ($builder, &$iterations) {
             $builder->add(
                 $file instanceof \SplFileInfo ?
-                    $file->getRealpath() :
-                    ($file instanceof MemberInterface ? $file->getLocation() : $file)
+                    $file->getRealpath() : ($file instanceof MemberInterface ? $file->getLocation() : $file)
             );
 
             $iterations++;

--- a/src/Adapter/AbstractTarAdapter.php
+++ b/src/Adapter/AbstractTarAdapter.php
@@ -89,7 +89,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
             ));
         }
 
-        return $this->parser->parseInflatorVersion($process->getOutput() ? : '');
+        return $this->parser->parseInflatorVersion($process->getOutput() ?: '');
     }
 
     /**
@@ -124,7 +124,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
             $builder->add('-f');
             $builder->add($path);
             $builder->add('-T');
-            $builder->add( $nullFile);
+            $builder->add($nullFile);
 
             $process = $builder->getProcess();
             $process->run();
@@ -141,7 +141,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
             $builder->setWorkingDirectory($collection->getContext());
 
-            $collection->forAll(function ($i, Resource $resource) use ($builder) {
+            $collection->forAll(function($i, Resource $resource) use ($builder) {
                 return $builder->add($resource->getTarget());
             });
 
@@ -200,7 +200,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
         $members = array();
 
-        foreach ($this->parser->parseFileListing($process->getOutput() ? : '') as $member) {
+        foreach ($this->parser->parseFileListing($process->getOutput() ?: '') as $member) {
             $members[] = new Member(
                     $resource,
                     $this,
@@ -240,7 +240,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function ($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, Resource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 
@@ -342,9 +342,12 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
             ));
         }
 
-        return new \SplFileInfo($to ? : $resource->getResource());
+        return new \SplFileInfo($to ?: $resource->getResource());
     }
 
+    /**
+     * @param string $to
+     */
     protected function doTarExtractMembers($options, ResourceInterface $resource, $members, $to = null, $overwrite = false)
     {
         if (null !== $to && !is_dir($to)) {

--- a/src/Adapter/AdapterContainer.php
+++ b/src/Adapter/AdapterContainer.php
@@ -42,7 +42,7 @@ class AdapterContainer implements \ArrayAccess
         $container['zip.inflator'] = null;
         $container['zip.deflator'] = null;
 
-        $container['resource-manager'] = function ($container) {
+        $container['resource-manager'] = function($container) {
             return new ResourceManager(
                 $container['request-mapper'],
                 $container['resource-teleporter'],
@@ -50,31 +50,31 @@ class AdapterContainer implements \ArrayAccess
             );
         };
 
-        $container['executable-finder'] = function ($container) {
+        $container['executable-finder'] = function($container) {
             return new ExecutableFinder();
         };
 
-        $container['request-mapper'] = function ($container) {
+        $container['request-mapper'] = function($container) {
             return new RequestMapper($container['target-locator']);
         };
 
-        $container['target-locator'] = function () {
+        $container['target-locator'] = function() {
             return new TargetLocator();
         };
 
-        $container['teleporter-container'] = function ($container) {
+        $container['teleporter-container'] = function($container) {
             return TeleporterContainer::load();
         };
 
-        $container['resource-teleporter'] = function ($container) {
+        $container['resource-teleporter'] = function($container) {
             return new ResourceTeleporter($container['teleporter-container']);
         };
 
-        $container['filesystem'] = function () {
+        $container['filesystem'] = function() {
             return new Filesystem();
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\ZipAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\ZipAdapter'] = function($container) {
             return ZipAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -86,7 +86,7 @@ class AdapterContainer implements \ArrayAccess
         $container['gnu-tar.inflator'] = null;
         $container['gnu-tar.deflator'] = null;
 
-        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGNUTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGNUTarAdapter'] = function($container) {
             return TarGNUTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -95,7 +95,7 @@ class AdapterContainer implements \ArrayAccess
             );
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarGzGNUTarAdapter'] = function($container) {
             return TarGzGNUTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -104,7 +104,7 @@ class AdapterContainer implements \ArrayAccess
             );
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\GNUTar\\TarBz2GNUTarAdapter'] = function($container) {
             return TarBz2GNUTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -116,7 +116,7 @@ class AdapterContainer implements \ArrayAccess
         $container['bsd-tar.inflator'] = null;
         $container['bsd-tar.deflator'] = null;
 
-        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBSDTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBSDTarAdapter'] = function($container) {
             return TarBSDTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -125,7 +125,7 @@ class AdapterContainer implements \ArrayAccess
             );
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarGzBSDTarAdapter'] = function($container) {
             return TarGzBSDTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -134,7 +134,7 @@ class AdapterContainer implements \ArrayAccess
             );
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'] = function ($container) {
+        $container['Alchemy\\Zippy\\Adapter\\BSDTar\\TarBz2BSDTarAdapter'] = function($container) {
             return TarBz2BSDTarAdapter::newInstance(
                 $container['executable-finder'],
                 $container['resource-manager'],
@@ -142,7 +142,7 @@ class AdapterContainer implements \ArrayAccess
                 $container['bsd-tar.deflator']);
         };
 
-        $container['Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'] = function () {
+        $container['Alchemy\\Zippy\\Adapter\\ZipExtensionAdapter'] = function() {
             return ZipExtensionAdapter::newInstance();
         };
 

--- a/src/Adapter/ZipAdapter.php
+++ b/src/Adapter/ZipAdapter.php
@@ -47,7 +47,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doCreate($path, $files, $recursive)
     {
-        $files = (array)$files;
+        $files = (array) $files;
 
         $builder = $this
             ->inflator
@@ -66,7 +66,7 @@ class ZipAdapter extends AbstractBinaryAdapter
         $collection = $this->manager->handle(getcwd(), $files);
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function ($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, Resource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 
@@ -135,7 +135,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doAdd(ResourceInterface $resource, $files, $recursive)
     {
-        $files = (array)$files;
+        $files = (array) $files;
 
         $builder = $this
             ->inflator
@@ -153,7 +153,7 @@ class ZipAdapter extends AbstractBinaryAdapter
 
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function ($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, Resource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 
@@ -230,7 +230,7 @@ class ZipAdapter extends AbstractBinaryAdapter
      */
     protected function doRemove(ResourceInterface $resource, $files)
     {
-        $files = (array)$files;
+        $files = (array) $files;
 
         $builder = $this
             ->inflator
@@ -330,7 +330,7 @@ class ZipAdapter extends AbstractBinaryAdapter
             throw new InvalidArgumentException(sprintf("%s is not a directory", $to));
         }
 
-        $members = (array)$members;
+        $members = (array) $members;
 
         $builder = $this
             ->deflator

--- a/src/Adapter/ZipExtensionAdapter.php
+++ b/src/Adapter/ZipExtensionAdapter.php
@@ -251,11 +251,11 @@ class ZipExtensionAdapter extends AbstractAdapter
         $adapter = $this;
 
         try {
-            $collection->forAll(function ($i, Resource $resource) use ($zipresource, $stack, $recursive, $adapter) {
+            $collection->forAll(function($i, Resource $resource) use ($zipresource, $stack, $recursive, $adapter) {
                 $adapter->checkReadability($zipresource->getResource(), $resource->getTarget());
                 if (is_dir($resource->getTarget())) {
                     if ($recursive) {
-                        $stack->push($resource->getTarget() . ((substr($resource->getTarget(), -1) === DIRECTORY_SEPARATOR) ? '' : DIRECTORY_SEPARATOR ));
+                        $stack->push($resource->getTarget() . ((substr($resource->getTarget(), -1) === DIRECTORY_SEPARATOR) ? '' : DIRECTORY_SEPARATOR));
                     } else {
                         $adapter->addEmptyDir($zipresource->getResource(), $resource->getTarget());
                     }
@@ -301,6 +301,7 @@ class ZipExtensionAdapter extends AbstractAdapter
 
     /**
      * @info is public for PHP 5.3 compatibility, should be private
+     * @param string $file
      */
     public function checkReadability(\ZipArchive $zip, $file)
     {
@@ -314,6 +315,7 @@ class ZipExtensionAdapter extends AbstractAdapter
 
     /**
      * @info is public for PHP 5.3 compatibility, should be private
+     * @param string $file
      */
     public function addFileToZip(\ZipArchive $zip, $file)
     {

--- a/src/Archive/Archive.php
+++ b/src/Archive/Archive.php
@@ -117,12 +117,12 @@ class Archive implements ArchiveInterface
     /**
      * @inheritdoc
      */
-     public function extract($toDirectory)
-     {
+        public function extract($toDirectory)
+        {
         $this->adapter->extract($this->resource, $toDirectory);
 
         return $this;
-     }
+        }
 
     /**
      * @inheritdoc

--- a/src/Archive/Member.php
+++ b/src/Archive/Member.php
@@ -132,7 +132,7 @@ class Member implements MemberInterface
      */
     public function extract($to = null, $overwrite = false)
     {
-        $this->adapter->extractMembers($this->resource, $this->location, $to, (bool)$overwrite);
+        $this->adapter->extractMembers($this->resource, $this->location, $to, (bool) $overwrite);
 
         return new \SplFileInfo(sprintf('%s%s', rtrim(null === $to ? getcwd() : $to, '/'), $this->location));
     }

--- a/src/Parser/BSDTarOutputParser.php
+++ b/src/Parser/BSDTarOutputParser.php
@@ -44,13 +44,13 @@ class BSDTarOutputParser implements ParserInterface
             // drw-rw-r--  0 toto titi     0 Jan  3  1980 practice/
             // -rw-rw-r--  0 toto titi     10240 Jan 22 13:31 practice/records
             if (!preg_match_all("#" .
-                self::PERMISSIONS   . "\s+" .   // match (drw-r--r--)
-                self::HARD_LINK     . "\s+" .   // match (1)
-                self::OWNER         . "\s" .    // match (toto)
-                self::GROUP         . "\s+" .   // match (titi)
-                self::FILESIZE      . "\s+" .   // match (0)
-                self::DATE          . "\s+" .   // match (Jan  3  1980)
-                self::FILENAME      .           // match (practice)
+                self::PERMISSIONS . "\s+" . // match (drw-r--r--)
+                self::HARD_LINK . "\s+" . // match (1)
+                self::OWNER . "\s" . // match (toto)
+                self::GROUP . "\s+" . // match (titi)
+                self::FILESIZE . "\s+" . // match (0)
+                self::DATE . "\s+" . // match (Jan  3  1980)
+                self::FILENAME . // match (practice)
                 "#", $line, $matches, PREG_SET_ORDER
             )) {
                 continue;
@@ -78,7 +78,7 @@ class BSDTarOutputParser implements ParserInterface
                 throw new RuntimeException(sprintf('Failed to parse mtime date from %s', $line));
             }
 
-             $members[] = array(
+                $members[] = array(
                 'location'  => $chunks[7],
                 'size'      => $chunks[5],
                 'mtime'     => $date,

--- a/src/Parser/ParserFactory.php
+++ b/src/Parser/ParserFactory.php
@@ -29,7 +29,7 @@ class ParserFactory
     /**
      * Maps the corresponding parser to the selected adapter
      *
-     * @param   $adapterName An adapter name
+     * @param   string $adapterName An adapter name
      *
      * @return ParserInterface
      *

--- a/src/Parser/ZipOutputParser.php
+++ b/src/Parser/ZipOutputParser.php
@@ -44,10 +44,10 @@ class ZipOutputParser implements ParserInterface
             $matches = array();
 
             // 785  2012-10-24 10:39  file
-            if (!preg_match_all("#".
-                self::LENGTH    . "\s+" . // match (785)
-                self::ISO_DATE  . "\s+" . // match (2012-10-24 10:39)
-                self::FILENAME  .         // match (file)
+            if (!preg_match_all("#" .
+                self::LENGTH . "\s+" . // match (785)
+                self::ISO_DATE . "\s+" . // match (2012-10-24 10:39)
+                self::FILENAME . // match (file)
                 "#",
                 $line, $matches, PREG_SET_ORDER
             )) {
@@ -71,9 +71,9 @@ class ZipOutputParser implements ParserInterface
         return $members;
     }
 
-      /**
-     * @inheritdoc
-     */
+        /**
+         * @inheritdoc
+         */
     public function parseInflatorVersion($output)
     {
         $lines = array_values(array_filter(explode("\n", $output, 3)));

--- a/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
+++ b/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
@@ -16,13 +16,13 @@ use Alchemy\Zippy\Exception\InvalidArgumentException;
 
 interface ProcessBuilderFactoryInterface
 {
-     /**
-     * Returns a new instance of Symfony ProcessBuilder
-     *
-     * @return ProcessBuilder
-     *
-     * @throws InvalidArgumentException
-     */
+        /**
+         * Returns a new instance of Symfony ProcessBuilder
+         *
+         * @return ProcessBuilder
+         *
+         * @throws InvalidArgumentException
+         */
     public function create();
 
     /**

--- a/src/Resource/Reader/Guzzle/GuzzleReader.php
+++ b/src/Resource/Reader/Guzzle/GuzzleReader.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Guzzle;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+use GuzzleHttp\ClientInterface;
+
+class GuzzleReader implements ResourceReader
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var \Alchemy\Zippy\Resource\Resource
+     */
+    private $resource;
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ClientInterface $client
+     */
+    public function __construct(Resource $resource, ClientInterface $client = null)
+    {
+        $this->resource = $resource;
+        $this->client = $client;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        return $this->buildRequest()->getBody()->getContents();
+    }
+
+    /**
+     * @return resource
+     */
+    public function getContentsAsStream()
+    {
+        $response = $this->buildRequest()->getBody()->getContents();
+        $stream = fopen('php://temp', 'r+');
+
+        if ($response != '') {
+            fwrite($stream, $response);
+            fseek($stream, 0);
+        }
+
+        return $stream;
+    }
+
+    private function buildRequest()
+    {
+        return $this->client->request('GET', $this->resource->getOriginal());
+    }
+}

--- a/src/Resource/Reader/Guzzle/GuzzleReaderFactory.php
+++ b/src/Resource/Reader/Guzzle/GuzzleReaderFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Guzzle;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+use Alchemy\Zippy\Resource\ResourceReaderFactory;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+
+class GuzzleReaderFactory implements ResourceReaderFactory
+{
+    /**
+     * @var ClientInterface|null
+     */
+    private $client = null;
+
+    public function __construct(ClientInterface $client = null)
+    {
+        $this->client = $client;
+
+        if (! $this->client) {
+            $this->client = new Client();
+        }
+    }
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string $context
+     * @return ResourceReader
+     */
+    public function getReader(Resource $resource, $context)
+    {
+        return new GuzzleReader($resource, $this->client);
+    }
+}

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Guzzle;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+use Guzzle\Http\Client;
+use Guzzle\Http\ClientInterface;
+use Guzzle\Http\EntityBodyInterface;
+
+class LegacyGuzzleReader implements ResourceReader
+{
+    /**
+     * @var ClientInterface
+     */
+    private $client;
+
+    /**
+     * @var \Alchemy\Zippy\Resource\Resource $resource
+     */
+    private $resource;
+
+    /**
+     * This is necessary to prevent the underlying PHP stream from being destroyed
+     * @link https://github.com/guzzle/guzzle/issues/366#issuecomment-20295409
+     * @var EntityBodyInterface|null
+     */
+    private $stream = null;
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ClientInterface $client
+     */
+    public function __construct(Resource $resource, ClientInterface $client = null)
+    {
+        $this->client = $client ?: new Client();
+        $this->resource = $resource;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        return $this->buildRequest()->send()->getBody(true);
+    }
+
+    /**
+     * @return resource
+     */
+    public function getContentsAsStream()
+    {
+        if (! $this->stream) {
+            $this->stream = $this->buildRequest()->send()->getBody(false);
+        }
+
+        return $this->stream->getStream();
+    }
+
+    /**
+     * @return \Guzzle\Http\Message\RequestInterface
+     */
+    private function buildRequest()
+    {
+        return $this->client->get($this->resource->getOriginal());
+    }
+}

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
@@ -50,7 +50,7 @@ class LegacyGuzzleReader implements ResourceReader
      */
     public function getContentsAsStream()
     {
-        if (! $this->stream) {
+        if (!$this->stream) {
             $this->stream = $this->buildRequest()->send()->getBody(false);
         }
 

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
@@ -21,10 +21,10 @@ class LegacyGuzzleReaderFactory implements ResourceReaderFactory
     {
         $this->client = $client;
 
-        if (! $this->client) {
+        if (!$this->client) {
             $this->client = new Client();
 
-            $this->client->getEventDispatcher()->addListener('request.error', function (Event $event) {
+            $this->client->getEventDispatcher()->addListener('request.error', function(Event $event) {
                 // override guzzle default behavior of throwing exceptions
                 // when 4xx & 5xx responses are encountered
                 $event->stopPropagation();

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Guzzle;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+use Alchemy\Zippy\Resource\ResourceReaderFactory;
+use Guzzle\Http\Client;
+use Guzzle\Http\ClientInterface;
+use Guzzle\Plugin\Backoff\BackoffPlugin;
+use Symfony\Component\EventDispatcher\Event;
+
+class LegacyGuzzleReaderFactory implements ResourceReaderFactory
+{
+    /**
+     * @var ClientInterface|null
+     */
+    private $client = null;
+
+    public function __construct(ClientInterface $client = null)
+    {
+        $this->client = $client;
+
+        if (! $this->client) {
+            $this->client = new Client();
+
+            $this->client->getEventDispatcher()->addListener('request.error', function (Event $event) {
+                // override guzzle default behavior of throwing exceptions
+                // when 4xx & 5xx responses are encountered
+                $event->stopPropagation();
+            }, -254);
+
+            $this->client->addSubscriber(BackoffPlugin::getExponentialBackoff(5, array(500, 502, 503, 408)));
+        }
+    }
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string $context
+     * @return ResourceReader
+     */
+    public function getReader(Resource $resource, $context)
+    {
+        return new LegacyGuzzleReader($resource, $this->client);
+    }
+}

--- a/src/Resource/Reader/Stream/StreamReader.php
+++ b/src/Resource/Reader/Stream/StreamReader.php
@@ -34,8 +34,7 @@ class StreamReader implements ResourceReader
     public function getContentsAsStream()
     {
         $stream = is_resource($this->resource->getOriginal()) ?
-            $this->resource->getOriginal() :
-            @fopen($this->resource->getOriginal(), 'rb');
+            $this->resource->getOriginal() : @fopen($this->resource->getOriginal(), 'rb');
 
         return $stream;
     }

--- a/src/Resource/Reader/Stream/StreamReader.php
+++ b/src/Resource/Reader/Stream/StreamReader.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Stream;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+
+class StreamReader implements ResourceReader
+{
+    /**
+     * @var \Alchemy\Zippy\Resource\Resource
+     */
+    private $resource;
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     */
+    public function __construct(Resource $resource)
+    {
+        $this->resource = $resource;
+    }
+
+    /**
+     * @return string
+     */
+    public function getContents()
+    {
+        return file_get_contents($this->resource->getOriginal());
+    }
+
+    /**
+     * @return resource
+     */
+    public function getContentsAsStream()
+    {
+        $stream = is_resource($this->resource->getOriginal()) ?
+            $this->resource->getOriginal() :
+            @fopen($this->resource->getOriginal(), 'rb');
+
+        return $stream;
+    }
+}

--- a/src/Resource/Reader/Stream/StreamReaderFactory.php
+++ b/src/Resource/Reader/Stream/StreamReaderFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Reader\Stream;
+
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceReader;
+use Alchemy\Zippy\Resource\ResourceReaderFactory;
+
+class StreamReaderFactory implements ResourceReaderFactory
+{
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string $context
+     * @return ResourceReader
+     */
+    public function getReader(Resource $resource, $context)
+    {
+        return new StreamReader($resource);
+    }
+}

--- a/src/Resource/Resource.php
+++ b/src/Resource/Resource.php
@@ -87,7 +87,7 @@ class Resource
             return null;
         }
 
-        if (PathUtil::basename($this->original)  === $this->target) {
+        if (PathUtil::basename($this->original) === $this->target) {
             return dirname($this->original);
         }
     }

--- a/src/Resource/ResourceCollection.php
+++ b/src/Resource/ResourceCollection.php
@@ -27,7 +27,7 @@ class ResourceCollection extends ArrayCollection
      */
     public function __construct($context, array $elements, $temporary)
     {
-        array_walk($elements, function ($element) {
+        array_walk($elements, function($element) {
             if (!$element instanceof Resource) {
                 throw new InvalidArgumentException('ResourceCollection only accept Resource elements');
             }

--- a/src/Resource/ResourceLocator.php
+++ b/src/Resource/ResourceLocator.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Alchemy\Zippy\Resource;
+
+class ResourceLocator
+{
+    public function mapResourcePath(Resource $resource, $context)
+    {
+        return rtrim($context, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $resource->getTarget();
+    }
+}

--- a/src/Resource/ResourceReader.php
+++ b/src/Resource/ResourceReader.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Alchemy\Zippy\Resource;
+
+interface ResourceReader 
+{
+    /**
+     * @return string
+     */
+    public function getContents();
+
+    /**
+     * @return resource
+     */
+    public function getContentsAsStream();
+}

--- a/src/Resource/ResourceReaderFactory.php
+++ b/src/Resource/ResourceReaderFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Alchemy\Zippy\Resource;
+
+interface ResourceReaderFactory
+{
+
+    /**
+     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string $context
+     * @return ResourceReader
+     */
+    public function getReader(Resource $resource, $context);
+}

--- a/src/Resource/ResourceTeleporter.php
+++ b/src/Resource/ResourceTeleporter.php
@@ -26,10 +26,10 @@ class ResourceTeleporter
     }
 
     /**
-     * Teleports a Resource to its target in the context
+     * Teleports a resource to its target in the context
      *
-     * @param String   $context
-     * @param Resource $resource
+     * @param string $context
+     * @param \Alchemy\Zippy\Resource\Resource $resource
      *
      * @return ResourceTeleporter
      */

--- a/src/Resource/ResourceWriter.php
+++ b/src/Resource/ResourceWriter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Alchemy\Zippy\Resource;
+
+interface ResourceWriter 
+{
+    public function writeFromReader(ResourceReader $reader, $target);
+}

--- a/src/Resource/TargetLocator.php
+++ b/src/Resource/TargetLocator.php
@@ -21,12 +21,12 @@ class TargetLocator
      * For example, adding /path/to/file where the context (current working
      * directory) is /path/to will return `file` as target
      *
-     * @param String          $context
-     * @param String|resource $resource
+     * @param string $context
+     * @param string|resource $resource
      *
-     * @return String
+     * @return string
      *
-     * @throws TargetLocatorException In case the resource is invalid
+     * @throws TargetLocatorException when the resource is invalid
      */
     public function locate($context, $resource)
     {
@@ -120,10 +120,9 @@ class TargetLocator
     /**
      * Checks whether the path belong to the context
      *
-     * @param String $path    A resource path
-     * @param String $context
-     *
-     * @return Boolean
+     * @param string $path    A resource path
+     * @param string $context
+     * @return bool
      */
     private function isFileInContext($path, $context)
     {
@@ -133,9 +132,9 @@ class TargetLocator
     /**
      * Gets the relative path from the context for the given path
      *
-     * @param String $path A resource path
-     *
-     * @return String
+     * @param string $path A resource path
+     * @param string $context
+     * @return string
      */
     private function getRelativePathFromContext($path, $context)
     {
@@ -143,11 +142,10 @@ class TargetLocator
     }
 
     /**
-     * Checks if a scheme reffers to a local filesystem
+     * Checks if a scheme refers to a local filesystem
      *
-     * @param String $scheme
-     *
-     * @return Boolean
+     * @param string $scheme
+     * @return bool
      */
     private function isLocalFilesystem($scheme)
     {

--- a/src/Resource/Teleporter/AbstractTeleporter.php
+++ b/src/Resource/Teleporter/AbstractTeleporter.php
@@ -37,7 +37,7 @@ abstract class AbstractTeleporter implements TeleporterInterface
     {
         $target = $this->getTarget($context, $resource);
 
-        if (! file_exists(dirname($target)) && false === mkdir(dirname($target))) {
+        if (!file_exists(dirname($target)) && false === mkdir(dirname($target))) {
             throw new IOException(sprintf('Could not create parent directory %s', dirname($target)));
         }
 

--- a/src/Resource/Teleporter/AbstractTeleporter.php
+++ b/src/Resource/Teleporter/AbstractTeleporter.php
@@ -14,6 +14,12 @@ namespace Alchemy\Zippy\Resource\Teleporter;
 use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Exception\IOException;
 
+/**
+ * Class AbstractTeleporter
+ * @package Alchemy\Zippy\Resource\Teleporter
+ *
+ * @deprecated Typehint against TeleporterInterface instead and use GenericTeleporter with custom reader/writers instead.
+ */
 abstract class AbstractTeleporter implements TeleporterInterface
 {
     /**
@@ -46,7 +52,7 @@ abstract class AbstractTeleporter implements TeleporterInterface
      * Returns the relative target of a Resource
      *
      * @param String   $context
-     * @param Resource $resource
+     * @param \Alchemy\Zippy\Resource\Resource $resource
      *
      * @return String
      */

--- a/src/Resource/Teleporter/GenericTeleporter.php
+++ b/src/Resource/Teleporter/GenericTeleporter.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Teleporter;
+
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Exception\IOException;
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\ResourceLocator;
+use Alchemy\Zippy\Resource\ResourceReaderFactory;
+use Alchemy\Zippy\Resource\ResourceWriter;
+
+class GenericTeleporter implements TeleporterInterface
+{
+    /**
+     * @var ResourceReaderFactory
+     */
+    private $readerFactory;
+
+    /**
+     * @var ResourceWriter
+     */
+    private $resourceWriter;
+
+    /**
+     * @var ResourceLocator
+     */
+    private $resourceLocator;
+
+    /**
+     * @param ResourceReaderFactory $readerFactory
+     * @param ResourceWriter $resourceWriter
+     * @param ResourceLocator $resourceLocator
+     */
+    public function __construct(
+        ResourceReaderFactory $readerFactory,
+        ResourceWriter $resourceWriter,
+        ResourceLocator $resourceLocator = null
+    ) {
+        $this->readerFactory = $readerFactory;
+        $this->resourceWriter = $resourceWriter;
+        $this->resourceLocator = $resourceLocator ?: new ResourceLocator();
+    }
+
+    /**
+     * Teleports a file from a destination to an other
+     *
+     * @param \Alchemy\Zippy\Resource\Resource $resource A Resource
+     * @param string $context The current context
+     *
+     * @throws IOException when file could not be written on local
+     * @throws InvalidArgumentException when path to file is not valid
+     */
+    public function teleport(Resource $resource, $context)
+    {
+        $reader = $this->readerFactory->getReader($resource, $context);
+        $target = $this->resourceLocator->mapResourcePath($resource, $context);
+
+        $this->resourceWriter->writeFromReader($reader, $target);
+    }
+}

--- a/src/Resource/Teleporter/GuzzleTeleporter.php
+++ b/src/Resource/Teleporter/GuzzleTeleporter.php
@@ -13,6 +13,7 @@ namespace Alchemy\Zippy\Resource\Teleporter;
 
 use Alchemy\Zippy\Resource\Reader\Guzzle\LegacyGuzzleReaderFactory;
 use Alchemy\Zippy\Resource\ResourceLocator;
+use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use Alchemy\Zippy\Resource\Writer\FilesystemWriter;
 use Guzzle\Http\Client;
 
@@ -23,16 +24,22 @@ class GuzzleTeleporter extends GenericTeleporter
 {
     /**
      * @param Client $client
+     * @param ResourceReaderFactory $readerFactory
      * @param ResourceLocator $resourceLocator
      */
-    public function __construct(Client $client = null, ResourceLocator $resourceLocator = null)
-    {
-        parent::__construct(new LegacyGuzzleReaderFactory($client), new FilesystemWriter(), $resourceLocator);
+    public function __construct(
+        Client $client = null,
+        ResourceReaderFactory $readerFactory = null,
+        ResourceLocator $resourceLocator = null
+    ) {
+        parent::__construct($readerFactory ?: new LegacyGuzzleReaderFactory($client), new FilesystemWriter(),
+            $resourceLocator);
     }
 
     /**
      * Creates the GuzzleTeleporter
      *
+     * @deprecated
      * @return GuzzleTeleporter
      */
     public static function create()

--- a/src/Resource/Teleporter/LocalTeleporter.php
+++ b/src/Resource/Teleporter/LocalTeleporter.php
@@ -14,6 +14,8 @@ namespace Alchemy\Zippy\Resource\Teleporter;
 use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Exception\IOException;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\ResourceLocator;
+use Alchemy\Zippy\Resource\TargetLocator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOException as SfIOException;
 
@@ -22,7 +24,15 @@ use Symfony\Component\Filesystem\Exception\IOException as SfIOException;
  */
 class LocalTeleporter extends AbstractTeleporter
 {
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
+
+    /**
+     * @var ResourceLocator
+     */
+    private $resourceLocator;
 
     /**
      * Constructor
@@ -32,6 +42,7 @@ class LocalTeleporter extends AbstractTeleporter
     public function __construct(Filesystem $filesystem)
     {
         $this->filesystem = $filesystem;
+        $this->resourceLocator = new ResourceLocator();
     }
 
     /**
@@ -39,7 +50,7 @@ class LocalTeleporter extends AbstractTeleporter
      */
     public function teleport(Resource $resource, $context)
     {
-        $target = $this->getTarget($context, $resource);
+        $target = $this->resourceLocator->mapResourcePath($resource, $context);
         $path = $resource->getOriginal();
 
         if (!file_exists($path)) {

--- a/src/Resource/Teleporter/LocalTeleporter.php
+++ b/src/Resource/Teleporter/LocalTeleporter.php
@@ -15,7 +15,6 @@ use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Exception\IOException;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Resource\ResourceLocator;
-use Alchemy\Zippy\Resource\TargetLocator;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOException as SfIOException;
 

--- a/src/Resource/Teleporter/StreamTeleporter.php
+++ b/src/Resource/Teleporter/StreamTeleporter.php
@@ -11,42 +11,18 @@
 
 namespace Alchemy\Zippy\Resource\Teleporter;
 
-use Alchemy\Zippy\Resource\Resource;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\Reader\Stream\StreamReaderFactory;
+use Alchemy\Zippy\Resource\ResourceLocator;
+use Alchemy\Zippy\Resource\Writer\StreamWriter;
 
 /**
  * This class transport an object using php stream wrapper
  */
-class StreamTeleporter extends AbstractTeleporter
+class StreamTeleporter extends GenericTeleporter
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function teleport(Resource $resource, $context)
+    public function __construct()
     {
-        $streamCreated = false;
-
-        if (is_resource($resource->getOriginal())) {
-            $stream = $resource->getOriginal();
-        } else {
-            $stream = @fopen($resource->getOriginal(), 'rb');
-
-            if (!is_resource($stream)) {
-                throw new InvalidArgumentException(sprintf(
-                    'The stream or file "%s" could not be opened: ',
-                    $resource->getOriginal()
-                ));
-            }
-            $streamCreated = true;
-        }
-
-        $content = stream_get_contents($stream);
-
-        if ($streamCreated) {
-            fclose($stream);
-        }
-
-        $this->writeTarget($content, $resource, $context);
+        parent::__construct(new StreamReaderFactory(), new StreamWriter(), new ResourceLocator());
     }
 
     /**

--- a/src/Resource/Teleporter/TeleporterInterface.php
+++ b/src/Resource/Teleporter/TeleporterInterface.php
@@ -11,18 +11,20 @@
 
 namespace Alchemy\Zippy\Resource\Teleporter;
 
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Exception\IOException;
 use Alchemy\Zippy\Resource\Resource;
 
 interface TeleporterInterface
 {
     /**
-     * Teleport a file from a destination to an other
+     * Teleports a file from a destination to an other
      *
-     * @param Resource $resource A Resource
-     * @param string   $context  The current context
+     * @param \Alchemy\Zippy\Resource\Resource $resource A Resource
+     * @param string $context The current context
      *
-     * @throws IOException              In case file could not be written on local
-     * @throws InvalidArgumentException In case path to file is not valid
+     * @throws IOException when file could not be written on local
+     * @throws InvalidArgumentException when path to file is not valid
      */
     public function teleport(Resource $resource, $context);
 }

--- a/src/Resource/TeleporterContainer.php
+++ b/src/Resource/TeleporterContainer.php
@@ -65,7 +65,7 @@ class TeleporterContainer implements \ArrayAccess, \Countable
 
     private function getTeleporter($typeName)
     {
-        if (! isset($this->teleporters[$typeName])) {
+        if (!isset($this->teleporters[$typeName])) {
             $factory = $this->factories[$typeName];
             $this->teleporters[$typeName] = $factory();
         }

--- a/src/Resource/TeleporterContainer.php
+++ b/src/Resource/TeleporterContainer.php
@@ -12,6 +12,7 @@
 namespace Alchemy\Zippy\Resource;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\Reader\Guzzle\GuzzleReaderFactory;
 use Alchemy\Zippy\Resource\Teleporter\LocalTeleporter;
 use Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter;
 use Alchemy\Zippy\Resource\Teleporter\StreamTeleporter;
@@ -89,9 +90,18 @@ class TeleporterContainer implements \ArrayAccess, \Countable
             return LocalTeleporter::create();
         };
 
-        if (class_exists('Guzzle\Http\Client')) {
+        if (class_exists('GuzzleHttp\Client')) {
             $container->factories['guzzle-teleporter'] = function () {
-                return GuzzleTeleporter::create();
+                return new GuzzleTeleporter(
+                    null,
+                    new GuzzleReaderFactory(),
+                    new ResourceLocator()
+                );
+            };
+        }
+        elseif (class_exists('Guzzle\Http\Client')) {
+            $container->factories['guzzle-teleporter'] = function () {
+                return new GuzzleTeleporter();
             };
         }
 

--- a/src/Resource/TeleporterContainer.php
+++ b/src/Resource/TeleporterContainer.php
@@ -35,7 +35,7 @@ class TeleporterContainer implements \ArrayAccess, \Countable
     /**
      * Returns the appropriate TeleporterInterface for a given Resource
      *
-     * @param Resource $resource
+     * @param \Alchemy\Zippy\Resource\Resource $resource
      * @return TeleporterInterface
      */
     public function fromResource(Resource $resource)

--- a/src/Resource/Writer/FilesystemWriter.php
+++ b/src/Resource/Writer/FilesystemWriter.php
@@ -4,19 +4,9 @@ namespace Alchemy\Zippy\Resource\Writer;
 
 use Alchemy\Zippy\Resource\ResourceReader;
 use Alchemy\Zippy\Resource\ResourceWriter;
-use Symfony\Component\Filesystem\Filesystem;
 
 class FilesystemWriter implements ResourceWriter
 {
-    /**
-     * @var Filesystem
-     */
-    private $filesystem;
-
-    public function __construct(Filesystem $filesystem = null)
-    {
-        $this->filesystem = $filesystem ?: new Filesystem();
-    }
 
     /**
      * @param ResourceReader $reader
@@ -24,6 +14,6 @@ class FilesystemWriter implements ResourceWriter
      */
     public function writeFromReader(ResourceReader $reader, $target)
     {
-        $this->filesystem->dumpFile($target, $reader->getContents());
+        file_put_contents($target, $reader->getContentsAsStream());
     }
 }

--- a/src/Resource/Writer/FilesystemWriter.php
+++ b/src/Resource/Writer/FilesystemWriter.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Writer;
+
+use Alchemy\Zippy\Resource\ResourceReader;
+use Alchemy\Zippy\Resource\ResourceWriter;
+use Symfony\Component\Filesystem\Filesystem;
+
+class FilesystemWriter implements ResourceWriter
+{
+    /**
+     * @var Filesystem
+     */
+    private $filesystem;
+
+    public function __construct(Filesystem $filesystem = null)
+    {
+        $this->filesystem = $filesystem ?: new Filesystem();
+    }
+
+    /**
+     * @param ResourceReader $reader
+     * @param string $target
+     */
+    public function writeFromReader(ResourceReader $reader, $target)
+    {
+        $this->filesystem->dumpFile($target, $reader->getContents());
+    }
+}

--- a/src/Resource/Writer/StreamWriter.php
+++ b/src/Resource/Writer/StreamWriter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Alchemy\Zippy\Resource\Writer;
+
+use Alchemy\Zippy\Resource\ResourceReader;
+use Alchemy\Zippy\Resource\ResourceWriter;
+
+class StreamWriter implements ResourceWriter
+{
+    /**
+     * @param ResourceReader $reader
+     * @param string $target
+     */
+    public function writeFromReader(ResourceReader $reader, $target)
+    {
+        $targetResource = fopen($target, 'w+');
+        $sourceResource = $reader->getContentsAsStream();
+
+        stream_copy_to_stream($sourceResource, $targetResource);
+        fclose($targetResource);
+    }
+}

--- a/tests/Tests/Resource/ResourceManagerTest.php
+++ b/tests/Tests/Resource/ResourceManagerTest.php
@@ -5,6 +5,7 @@ namespace Alchemy\Zippy\Tests\Resource;
 use Alchemy\Zippy\Resource\ResourceCollection;
 use Alchemy\Zippy\Tests\TestCase;
 use Alchemy\Zippy\Resource\ResourceManager;
+use Symfony\Component\Filesystem\Filesystem;
 
 class ResourceManagerTest extends TestCase
 {
@@ -153,29 +154,29 @@ class ResourceManagerTest extends TestCase
      */
     public function testFunctionnal()
     {
-        $wd = __DIR__;
-        $tmpdir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
+        $workDir = __DIR__;
+        $tempDir = rtrim(sys_get_temp_dir(), DIRECTORY_SEPARATOR);
 
-        $filesystem = new \Symfony\Component\Filesystem\Filesystem();
-        $filesystem->mkdir($tmpdir . '/path/to/local/');
-        $filesystem->mkdir($tmpdir . '/to/');
-        $filesystem->mkdir($tmpdir . '/path/to/a');
+        $filesystem = new Filesystem();
+        $filesystem->mkdir($tempDir . '/path/to/local/');
+        $filesystem->mkdir($tempDir . '/to/');
+        $filesystem->mkdir($tempDir . '/path/to/a');
 
-        touch($tmpdir . '/path/to/local/file.ext');
-        touch($tmpdir . '/path/to/local/file2.ext');
-        touch($tmpdir . '/to/file3.ext');
+        $filesystem->touch($tempDir . '/path/to/local/file.ext');
+        $filesystem->touch($tempDir . '/path/to/local/file2.ext');
+        $filesystem->touch($tempDir . '/to/file3.ext');
 
         $request = array(
-            $wd . '/input/path/to/local/file.ext',
-            $wd . '/input/path/to/a/../local/file2.ext',
-            $tmpdir . '/path/to/local/file.ext',
-            $tmpdir . '/path/to/a/../local/file2.ext',
+            $workDir . '/input/path/to/local/file.ext',
+            $workDir . '/input/path/to/a/../local/file2.ext',
+            $tempDir . '/path/to/local/file.ext',
+            $tempDir . '/path/to/a/../local/file2.ext',
             'http://127.0.0.1:8080/plus-badge.png',
             'http://127.0.0.1:8080/plusone-button.png',
-            'file://' . $tmpdir . '/to/file3.ext',
-            'file://' . $wd . '/input/path/to/a/../local/file3.ext',
-            '/I/want/this/file/to/go/there' => 'file://' . $wd . '/input/path/to/local/file2.ext',
-            '/I/want/this/file/to/go/here'  => 'file://' . $wd . '/input/path/to/local/file3.ext'
+            'file://' . $tempDir . '/to/file3.ext',
+            'file://' . $workDir . '/input/path/to/a/../local/file3.ext',
+            '/I/want/this/file/to/go/there' => 'file://' . $workDir . '/input/path/to/local/file2.ext',
+            '/I/want/this/file/to/go/here'  => 'file://' . $workDir . '/input/path/to/local/file3.ext'
         );
 
         $expected = array(
@@ -205,7 +206,7 @@ class ResourceManagerTest extends TestCase
 
         $resourceManger = ResourceManager::create();
 
-        $collection = $resourceManger->handle($wd, $request);
+        $collection = $resourceManger->handle($workDir, $request);
 
         $this->assertCount(10, $collection);
 

--- a/tests/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
@@ -18,7 +18,7 @@ class GuzzleTeleporterTest extends TeleporterTestCase
         $target = 'plop-badge.png';
         $resource = new Resource('http://127.0.0.1:8080/plus-badge.png', $target);
 
-        if (is_file($target)) {
+        if (is_file($context . '/' . $target)) {
             unlink($context . '/' . $target);
         }
 

--- a/tests/Tests/Resource/Teleporter/LocalTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/LocalTeleporterTest.php
@@ -18,7 +18,7 @@ class LocalTeleporterTest extends TeleporterTestCase
         $target = 'plop-badge.php';
         $resource = new Resource(__FILE__, $target);
 
-        if (is_file($target)) {
+        if (is_file($context . '/' . $target)) {
             unlink($context . '/' . $target);
         }
 
@@ -39,7 +39,7 @@ class LocalTeleporterTest extends TeleporterTestCase
         $target = 'plop-badge.php';
         $resource = new Resource('file://' . __FILE__, $target);
 
-        if (is_file($target)) {
+        if (is_file($context . '/' . $target)) {
             unlink($context . '/' . $target);
         }
 
@@ -50,9 +50,8 @@ class LocalTeleporterTest extends TeleporterTestCase
     }
 
     /**
-     * @covers Alchemy\Zippy\Resource\Teleporter\LocalTeleporter::teleport
      * @dataProvider provideInvalidSources
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testTeleportOnNonExistentFile($source)
     {
@@ -73,7 +72,6 @@ class LocalTeleporterTest extends TeleporterTestCase
     }
 
     /**
-     * @covers Alchemy\Zippy\Resource\Teleporter\LocalTeleporter::teleport
      * @dataProvider provideContexts
      */
     public function testTeleportADir($context)
@@ -86,6 +84,7 @@ class LocalTeleporterTest extends TeleporterTestCase
         if (!is_dir(__DIR__ . '/plop-badge')) {
             mkdir(__DIR__ . '/plop-badge');
         }
+
         if (!is_file(__DIR__ . '/plop-badge/test-file.png')) {
             touch(__DIR__ . '/plop-badge/test-file.png');
         }

--- a/tests/Tests/Resource/Teleporter/StreamTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/StreamTeleporterTest.php
@@ -18,7 +18,7 @@ class StreamTeleporterTest extends TeleporterTestCase
         $target = 'plop-badge.php';
         $resource = new Resource(fopen(__FILE__, 'rb'), $target);
 
-        if (is_file($target)) {
+        if (is_file($context . '/' . $target)) {
             unlink($context . '/' . $target);
         }
 
@@ -39,7 +39,7 @@ class StreamTeleporterTest extends TeleporterTestCase
         $target = 'plop-badge.php';
         $resource = new Resource(__FILE__, $target);
 
-        if (is_file($target)) {
+        if (is_file($context . '/' . $target)) {
             unlink($context . '/' . $target);
         }
 


### PR DESCRIPTION
Aim is to move away from using the abstract teleporter class and to instead create new teleporters via resource readers and writers. Main advantage is that it will now require less work to provide new reader and writer types.

Additionally, this P/R fixes a bug in tests: before testing teleporters, the unit tests were checking for the existence of the target file using its relative path, but attempting to delete the file using an absolute path which had no guarantee of being the same as the working directory.