### PR TITLE
PHPDoc & ZippyResource

### DIFF
--- a/src/Adapter/AbstractAdapter.php
+++ b/src/Adapter/AbstractAdapter.php
@@ -12,14 +12,14 @@
 
 namespace Alchemy\Zippy\Adapter;
 
+use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface;
 use Alchemy\Zippy\Archive\Archive;
 use Alchemy\Zippy\Archive\ArchiveInterface;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Alchemy\Zippy\Resource\ResourceManager;
-use Alchemy\Zippy\Resource\PathUtil;
-use Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface;
 use Alchemy\Zippy\Exception\RuntimeException;
-use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\PathUtil;
+use Alchemy\Zippy\Resource\ResourceManager;
 
 abstract class AbstractAdapter implements AdapterInterface
 {
@@ -121,6 +121,8 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Sets the version probe used by this adapter
      *
+     * @param VersionProbeInterface $probe
+     *
      * @return VersionProbeInterface
      */
     public function setVersionProbe(VersionProbeInterface $probe)
@@ -177,6 +179,8 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Creates a resource given a path
      *
+     * @param string $path
+     *
      * @return ResourceInterface
      */
     abstract protected function createResource($path);
@@ -184,19 +188,29 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Do the removal after having check that the current adapter is supported
      *
-     * @return Array
+     * @param ResourceInterface $resource
+     * @param array             $files
+     *
+     * @return array
      */
     abstract protected function doRemove(ResourceInterface $resource, $files);
 
     /**
      * Do the add after having check that the current adapter is supported
      *
-     * @return Array
+     * @param ResourceInterface $resource
+     * @param array             $files
+     * @param bool              $recursive
+     *
+     * @return array
      */
     abstract protected function doAdd(ResourceInterface $resource, $files, $recursive);
 
     /**
      * Do the extract after having check that the current adapter is supported
+     *
+     * @param ResourceInterface $resource
+     * @param                   $to
      *
      * @return \SplFileInfo The extracted archive
      */
@@ -206,9 +220,10 @@ abstract class AbstractAdapter implements AdapterInterface
      * Do the extract members after having check that the current adapter is supported
      *
      * @param ResourceInterface $resource
-     * @param string|string[] $members
-     * @param string $to
-     * @param bool $overwrite
+     * @param string|string[]   $members
+     * @param string            $to
+     * @param bool              $overwrite
+     *
      * @return \SplFileInfo The extracted archive
      */
     abstract protected function doExtractMembers(ResourceInterface $resource, $members, $to, $overwrite = false);
@@ -216,12 +231,18 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Do the list members after having check that the current adapter is supported
      *
-     * @return Array
+     * @param ResourceInterface $resource
+     *
+     * @return array
      */
     abstract protected function doListMembers(ResourceInterface $resource);
 
     /**
      * Do the create after having check that the current adapter is supported
+     *
+     * @param string $path
+     * @param string $file
+     * @param bool   $recursive
      *
      * @return ArchiveInterface
      */
@@ -230,7 +251,7 @@ abstract class AbstractAdapter implements AdapterInterface
     /**
      * Makes the target path absolute as the adapters might have a different directory
      *
-     * @param $path The path to convert
+     * @param string $path The path to convert
      *
      * @return string The absolute path
      *

--- a/src/Adapter/AbstractBinaryAdapter.php
+++ b/src/Adapter/AbstractBinaryAdapter.php
@@ -14,8 +14,8 @@ namespace Alchemy\Zippy\Adapter;
 
 use Alchemy\Zippy\Adapter\Resource\FileResource;
 use Alchemy\Zippy\Archive\MemberInterface;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Parser\ParserFactory;
 use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory;
@@ -62,7 +62,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
         ProcessBuilderFactoryInterface $deflator
     ) {
         $this->parser = $parser;
-        $this->manager = $manager;
+        parent::__construct($manager);
         $this->deflator = $deflator;
         $this->inflator = $inflator;
     }
@@ -141,12 +141,12 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
     /**
      * Returns a new instance of the invoked adapter
      *
-     * @params String|null $inflatorBinaryName The inflator binary name to use
-     * @params String|null $deflatorBinaryName The deflator binary name to use
+     * @param ExecutableFinder $finder
+     * @param ResourceManager  $manager
+     * @param string|null      $inflatorBinaryName The inflator binary name to use
+     * @param string|null      $deflatorBinaryName The deflator binary name to use
      *
      * @return AbstractBinaryAdapter
-     *
-     * @throws RuntimeException In case object could not be instanciated
      */
     public static function newInstance(
         ExecutableFinder $finder,
@@ -198,10 +198,10 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
     /**
      * Adds files to argument list
      *
-     * @param Array $files An array of files
-     * @param ProcessBuilder $builder A Builder instance
+     * @param MemberInterface[]|\SplFileInfo[]|string[] $files   An array of files
+     * @param ProcessBuilder                            $builder A Builder instance
      *
-     * @return Boolean
+     * @return bool
      */
     protected function addBuilderFileArgument(array $files, ProcessBuilder $builder)
     {
@@ -210,7 +210,7 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
         array_walk($files, function($file) use ($builder, &$iterations) {
             $builder->add(
                 $file instanceof \SplFileInfo ?
-                    $file->getRealpath() : ($file instanceof MemberInterface ? $file->getLocation() : $file)
+                    $file->getRealPath() : ($file instanceof MemberInterface ? $file->getLocation() : $file)
             );
 
             $iterations++;

--- a/src/Adapter/AbstractTarAdapter.php
+++ b/src/Adapter/AbstractTarAdapter.php
@@ -13,10 +13,10 @@ namespace Alchemy\Zippy\Adapter;
 
 use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
 use Alchemy\Zippy\Archive\Archive;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Alchemy\Zippy\Exception\RuntimeException;
-use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Archive\Member;
+use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 
 abstract class AbstractTarAdapter extends AbstractBinaryAdapter
@@ -141,7 +141,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
             $builder->setWorkingDirectory($collection->getContext());
 
-            $collection->forAll(function($i, Resource $resource) use ($builder) {
+            $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
                 return $builder->add($resource->getTarget());
             });
 
@@ -240,7 +240,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 
@@ -346,7 +346,13 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     }
 
     /**
-     * @param string $to
+     * @param array             $options
+     * @param ResourceInterface $resource
+     * @param array             $members
+     * @param string            $to
+     * @param bool              $overwrite
+     *
+     * @return array
      */
     protected function doTarExtractMembers($options, ResourceInterface $resource, $members, $to = null, $overwrite = false)
     {
@@ -405,28 +411,28 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     /**
      * Returns an array of option for the listMembers command
      *
-     * @return Array
+     * @return array
      */
     abstract protected function getListMembersOptions();
 
     /**
      * Returns an array of option for the extract command
      *
-     * @return Array
+     * @return array
      */
     abstract protected function getExtractOptions();
 
     /**
      * Returns an array of option for the extractMembers command
      *
-     * @return Array
+     * @return array
      */
     abstract protected function getExtractMembersOptions();
 
     /**
      * Gets adapter specific additional options
      *
-     * @return Array
+     * @return array
      */
     abstract protected function getLocalOptions();
 }

--- a/src/Adapter/AdapterContainer.php
+++ b/src/Adapter/AdapterContainer.php
@@ -12,16 +12,16 @@
 namespace Alchemy\Zippy\Adapter;
 
 use Alchemy\Zippy\Adapter\BSDTar\TarBSDTarAdapter;
-use Alchemy\Zippy\Adapter\BSDTar\TarGzBSDTarAdapter;
 use Alchemy\Zippy\Adapter\BSDTar\TarBz2BSDTarAdapter;
+use Alchemy\Zippy\Adapter\BSDTar\TarGzBSDTarAdapter;
+use Alchemy\Zippy\Adapter\GNUTar\TarBz2GNUTarAdapter;
 use Alchemy\Zippy\Adapter\GNUTar\TarGNUTarAdapter;
 use Alchemy\Zippy\Adapter\GNUTar\TarGzGNUTarAdapter;
-use Alchemy\Zippy\Adapter\GNUTar\TarBz2GNUTarAdapter;
-use Alchemy\Zippy\Resource\ResourceManager;
 use Alchemy\Zippy\Resource\RequestMapper;
-use Alchemy\Zippy\Resource\TeleporterContainer;
+use Alchemy\Zippy\Resource\ResourceManager;
 use Alchemy\Zippy\Resource\ResourceTeleporter;
 use Alchemy\Zippy\Resource\TargetLocator;
+use Alchemy\Zippy\Resource\TeleporterContainer;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Process\ExecutableFinder;
 
@@ -152,14 +152,15 @@ class AdapterContainer implements \ArrayAccess
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Whether a offset exists
+     *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
      * @param mixed $offset <p>
-     * An offset to check for.
-     * </p>
-     * @return boolean true on success or false on failure.
-     * </p>
-     * <p>
-     * The return value will be casted to boolean if non-boolean was returned.
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return bool true on success or false on failure.
+     * <p>The return value will be casted to boolean if non-boolean was returned.</p>
      */
     public function offsetExists($offset)
     {

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -13,10 +13,9 @@ namespace Alchemy\Zippy\Adapter;
 
 use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
 use Alchemy\Zippy\Archive\ArchiveInterface;
-use Alchemy\Zippy\Archive\MemberInterface;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\NotSupportedException;
 use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
 
 Interface AdapterInterface
 {
@@ -38,9 +37,9 @@ Interface AdapterInterface
      * Please note some adapters can not create empty archives.
      * They would throw a `NotSupportedException` in case you ask to create an archive without files
      *
-     * @param string $path The path to the archive
-     * @param string|string[]|\Traversable|null $files A filename, an array of files, or a \Traversable instance
-     * @param bool $recursive Whether to recurse or not in the provided directories
+     * @param string                            $path      The path to the archive
+     * @param string|string[]|\Traversable|null $files     A filename, an array of files, or a \Traversable instance
+     * @param bool                              $recursive Whether to recurse or not in the provided directories
      *
      * @return ArchiveInterface
      *
@@ -71,9 +70,9 @@ Interface AdapterInterface
     /**
      * Adds a file to the archive
      *
-     * @param ResourceInterface $resource The path to the archive
-     * @param string|array|\Traversable $files An array of paths to add, relative to cwd
-     * @param bool $recursive Whether or not to recurse in the provided directories
+     * @param ResourceInterface         $resource  The path to the archive
+     * @param string|array|\Traversable $files     An array of paths to add, relative to cwd
+     * @param bool                      $recursive Whether or not to recurse in the provided directories
      *
      * @return array
      *
@@ -85,10 +84,10 @@ Interface AdapterInterface
     /**
      * Removes a member of the archive
      *
-     * @param ResourceInterface $resource The path to the archive
-     * @param String|Array|\Traversable $files A filename, an array of files, or a \Traversable instance
+     * @param ResourceInterface         $resource The path to the archive
+     * @param string|array|\Traversable $files    A filename, an array of files, or a \Traversable instance
      *
-     * @return Array
+     * @return array
      *
      * @throws RuntimeException In case of failure
      * @throws InvalidArgumentException In case no files could be removed
@@ -101,7 +100,7 @@ Interface AdapterInterface
      * Note that any existing files will be overwritten by the adapter
      *
      * @param ResourceInterface $resource The path to the archive
-     * @param string|null $to The path where to extract the archive
+     * @param string|null       $to       The path where to extract the archive
      *
      * @return \SplFileInfo The extracted archive
      *
@@ -113,10 +112,10 @@ Interface AdapterInterface
     /**
      * Extracts specific members of the archive
      *
-     * @param ResourceInterface $resource The path to the archive
-     * @param string|string[] $members A path or array of paths matching the members to extract from the resource.
-     * @param string|null $to The path where to extract the members
-     * @param bool $overwrite Whether to overwrite existing files in target directory
+     * @param ResourceInterface $resource  The path to the archive
+     * @param string|string[]   $members   A path or array of paths matching the members to extract from the resource.
+     * @param string|null       $to        The path where to extract the members
+     * @param bool              $overwrite Whether to overwrite existing files in target directory
      *
      * @return \SplFileInfo The extracted archive
      *
@@ -128,7 +127,7 @@ Interface AdapterInterface
     /**
      * Returns the adapter name
      *
-     * @return String
+     * @return string
      */
     public static function getName();
 }

--- a/src/Adapter/BinaryAdapterInterface.php
+++ b/src/Adapter/BinaryAdapterInterface.php
@@ -67,28 +67,28 @@ interface BinaryAdapterInterface
     /**
      * Returns the inflator binary version
      *
-     * @return String
+     * @return string
      */
     public function getInflatorVersion();
 
     /**
      * Returns the deflator binary version
      *
-     * @return String
+     * @return string
      */
     public function getDeflatorVersion();
 
     /**
      * Gets the inflator adapter binary name
      *
-     * @return Array
+     * @return array
      */
     public static function getDefaultInflatorBinaryName();
 
     /**
      * Gets the deflator adapter binary name
      *
-     * @return Array
+     * @return array
      */
     public static function getDefaultDeflatorBinaryName();
 }

--- a/src/Adapter/VersionProbe/AbstractTarVersionProbe.php
+++ b/src/Adapter/VersionProbe/AbstractTarVersionProbe.php
@@ -13,6 +13,7 @@
 namespace Alchemy\Zippy\Adapter\VersionProbe;
 
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
+use Symfony\Component\Process\Process;
 
 abstract class AbstractTarVersionProbe implements VersionProbeInterface
 {
@@ -42,6 +43,7 @@ abstract class AbstractTarVersionProbe implements VersionProbeInterface
         $good = true;
 
         foreach (array($this->inflator, $this->deflator) as $builder) {
+            /** @var Process $process */
             $process = $builder
                 ->create()
                 ->add('--version')

--- a/src/Adapter/ZipAdapter.php
+++ b/src/Adapter/ZipAdapter.php
@@ -20,7 +20,7 @@ use Alchemy\Zippy\Exception\NotSupportedException;
 use Alchemy\Zippy\Exception\RuntimeException;
 use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceManager;
 use Symfony\Component\Process\Exception\ExceptionInterface as ProcessException;
 
@@ -66,7 +66,7 @@ class ZipAdapter extends AbstractBinaryAdapter
         $collection = $this->manager->handle(getcwd(), $files);
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 
@@ -153,7 +153,7 @@ class ZipAdapter extends AbstractBinaryAdapter
 
         $builder->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, Resource $resource) use ($builder) {
+        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
             return $builder->add($resource->getTarget());
         });
 

--- a/src/Adapter/ZipExtensionAdapter.php
+++ b/src/Adapter/ZipExtensionAdapter.php
@@ -11,16 +11,16 @@
 
 namespace Alchemy\Zippy\Adapter;
 
-use Alchemy\Zippy\Exception\RuntimeException;
-use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Alchemy\Zippy\Exception\NotSupportedException;
-use Alchemy\Zippy\Archive\Member;
 use Alchemy\Zippy\Adapter\Resource\ResourceInterface;
 use Alchemy\Zippy\Adapter\Resource\ZipArchiveResource;
 use Alchemy\Zippy\Adapter\VersionProbe\ZipExtensionVersionProbe;
 use Alchemy\Zippy\Archive\Archive;
+use Alchemy\Zippy\Archive\Member;
+use Alchemy\Zippy\Exception\NotSupportedException;
+use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceManager;
-use Alchemy\Zippy\Resource\Resource;
 
 /**
  * ZipExtensionAdapter allows you to create and extract files from archives
@@ -238,7 +238,7 @@ class ZipExtensionAdapter extends AbstractAdapter
         return new ZipArchiveResource($zip);
     }
 
-    private function addEntries(ZipArchiveResource $zipresource, array $files, $recursive)
+    private function addEntries(ResourceInterface $zipResource, array $files, $recursive)
     {
         $stack = new \SplStack();
 
@@ -251,16 +251,16 @@ class ZipExtensionAdapter extends AbstractAdapter
         $adapter = $this;
 
         try {
-            $collection->forAll(function($i, Resource $resource) use ($zipresource, $stack, $recursive, $adapter) {
-                $adapter->checkReadability($zipresource->getResource(), $resource->getTarget());
+            $collection->forAll(function($i, ZippyResource $resource) use ($zipResource, $stack, $recursive, $adapter) {
+                $adapter->checkReadability($zipResource->getResource(), $resource->getTarget());
                 if (is_dir($resource->getTarget())) {
                     if ($recursive) {
                         $stack->push($resource->getTarget() . ((substr($resource->getTarget(), -1) === DIRECTORY_SEPARATOR) ? '' : DIRECTORY_SEPARATOR));
                     } else {
-                        $adapter->addEmptyDir($zipresource->getResource(), $resource->getTarget());
+                        $adapter->addEmptyDir($zipResource->getResource(), $resource->getTarget());
                     }
                 } else {
-                    $adapter->addFileToZip($zipresource->getResource(), $resource->getTarget());
+                    $adapter->addFileToZip($zipResource->getResource(), $resource->getTarget());
                 }
 
                 return true;
@@ -274,18 +274,18 @@ class ZipExtensionAdapter extends AbstractAdapter
                 if (count($files) > 0) {
                     foreach ($files as $file) {
                         $file = $dir . $file;
-                        $this->checkReadability($zipresource->getResource(), $file);
+                        $this->checkReadability($zipResource->getResource(), $file);
                         if (is_dir($file)) {
                             $stack->push($file . DIRECTORY_SEPARATOR);
                         } else {
-                            $this->addFileToZip($zipresource->getResource(), $file);
+                            $this->addFileToZip($zipResource->getResource(), $file);
                         }
                     }
                 } else {
-                    $this->addEmptyDir($zipresource->getResource(), $dir);
+                    $this->addEmptyDir($zipResource->getResource(), $dir);
                 }
             }
-            $this->flush($zipresource->getResource());
+            $this->flush($zipResource->getResource());
 
             $this->manager->cleanup($collection);
         } catch (\Exception $e) {
@@ -301,7 +301,9 @@ class ZipExtensionAdapter extends AbstractAdapter
 
     /**
      * @info is public for PHP 5.3 compatibility, should be private
-     * @param string $file
+     *
+     * @param \ZipArchive $zip
+     * @param string      $file
      */
     public function checkReadability(\ZipArchive $zip, $file)
     {
@@ -315,7 +317,9 @@ class ZipExtensionAdapter extends AbstractAdapter
 
     /**
      * @info is public for PHP 5.3 compatibility, should be private
-     * @param string $file
+     *
+     * @param \ZipArchive $zip
+     * @param string      $file
      */
     public function addFileToZip(\ZipArchive $zip, $file)
     {
@@ -329,6 +333,9 @@ class ZipExtensionAdapter extends AbstractAdapter
 
     /**
      * @info is public for PHP 5.3 compatibility, should be private
+     *
+     * @param \ZipArchive $zip
+     * @param string      $dir
      */
     public function addEmptyDir(\ZipArchive $zip, $dir)
     {

--- a/src/Archive/Archive.php
+++ b/src/Archive/Archive.php
@@ -23,7 +23,7 @@ class Archive implements ArchiveInterface
     /**
      * The path to the archive
      *
-     * @var String
+     * @var string
      */
     protected $path;
 
@@ -37,7 +37,7 @@ class Archive implements ArchiveInterface
     /**
      * An array of archive members
      *
-     * @var Array
+     * @var MemberInterface[]
      */
     protected $members = array();
 

--- a/src/Archive/ArchiveInterface.php
+++ b/src/Archive/ArchiveInterface.php
@@ -11,16 +11,16 @@
 
 namespace Alchemy\Zippy\Archive;
 
-use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
 
 interface ArchiveInterface extends \IteratorAggregate, \Countable
 {
     /**
      * Adds a file or a folder into the archive
      *
-     * @param String|Array|\SplFileInfo $sources   The path to the file or a folder
-     * @param Boolean                   $recursive Recurse into sub-directories
+     * @param string|array|\SplFileInfo $sources   The path to the file or a folder
+     * @param bool                      $recursive Recurse into sub-directories
      *
      * @return ArchiveInterface
      *
@@ -32,7 +32,7 @@ interface ArchiveInterface extends \IteratorAggregate, \Countable
     /**
      * Removes a file from the archive
      *
-     * @param String|Array $sources The path to an archive or a folder member
+     * @param string|array $sources The path to an archive or a folder member
      *
      * @return ArchiveInterface
      *
@@ -43,7 +43,7 @@ interface ArchiveInterface extends \IteratorAggregate, \Countable
     /**
      * Lists files and directories archive members
      *
-     * @return Array An array of File
+     * @return MemberInterface[] An array of File
      *
      * @throws RuntimeException In case archive could not be read
      */
@@ -52,7 +52,7 @@ interface ArchiveInterface extends \IteratorAggregate, \Countable
     /**
      * Extracts current archive to the given directory
      *
-     * @param String $toDirectory The path the extracted archive
+     * @param string $toDirectory The path the extracted archive
      *
      * @return ArchiveInterface
      *
@@ -63,8 +63,8 @@ interface ArchiveInterface extends \IteratorAggregate, \Countable
     /**
      * Extracts specific members from the archive
      *
-     * @param String|Array $members     An array of members path
-     * @param string       $toDirectory The destination $directory
+     * @param string|MemberInterface[] $members     An array of members path
+     * @param string                   $toDirectory The destination $directory
      *
      * @return ArchiveInterface
      *

--- a/src/Archive/MemberInterface.php
+++ b/src/Archive/MemberInterface.php
@@ -11,22 +11,22 @@
 
 namespace Alchemy\Zippy\Archive;
 
-use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\RuntimeException;
+use Alchemy\Zippy\Exception\InvalidArgumentException;
 
 interface MemberInterface
 {
     /**
      * Gets the location of an archive member
      *
-     * @return String
+     * @return string
      */
     public function getLocation();
 
     /**
      * Tells whether the member is a directory or not
      *
-     * @return Boolean
+     * @return bool
      */
     public function isDir();
 
@@ -42,7 +42,7 @@ interface MemberInterface
      *
      * If the size is unknown, returns -1
      *
-     * @return Integer
+     * @return integer
      */
     public function getSize();
 
@@ -53,8 +53,8 @@ interface MemberInterface
      * This will execute one extraction process for each file
      * Prefer the use of ArchiveInterface::extractMembers in that use case
      *
-     * @param string|null $to The path where to extract the member, if no path is not provided the member is extracted in the same directory of its archive
-     * @param bool $overwrite Whether to overwrite destination file if it already exists. Defaults to false
+     * @param string|null $to        The path where to extract the member, if no path is not provided the member is extracted in the same directory of its archive
+     * @param bool        $overwrite Whether to overwrite destination file if it already exists. Defaults to false
      *
      * @return \SplFileInfo The extracted file
      *

--- a/src/Parser/BSDTarOutputParser.php
+++ b/src/Parser/BSDTarOutputParser.php
@@ -17,13 +17,13 @@ use Alchemy\Zippy\Exception\RuntimeException;
  */
 class BSDTarOutputParser implements ParserInterface
 {
-    const PERMISSIONS   = "([ldrwx-]+)";
-    const HARD_LINK     = "(\d+)";
-    const OWNER         = "([a-z][-a-z0-9]*)";
-    const GROUP         = "([a-z][-a-z0-9]*)";
-    const FILESIZE      = "(\d*)";
-    const DATE          = "([a-zA-Z0-9]+\s+[a-z0-9]+\s+[a-z0-9:]+)";
-    const FILENAME      = "(.*)";
+    const PERMISSIONS   = '([ldrwx-]+)';
+    const HARD_LINK     = '(\d+)';
+    const OWNER         = '([a-z][-a-z0-9]*)';
+    const GROUP         = '([a-z][-a-z0-9]*)';
+    const FILESIZE      = '(\d*)';
+    const DATE          = '([a-zA-Z0-9]+\s+[a-z0-9]+\s+[a-z0-9:]+)';
+    const FILENAME      = '(.*)';
 
     /**
      * @inheritdoc
@@ -78,7 +78,7 @@ class BSDTarOutputParser implements ParserInterface
                 throw new RuntimeException(sprintf('Failed to parse mtime date from %s', $line));
             }
 
-                $members[] = array(
+            $members[] = array(
                 'location'  => $chunks[7],
                 'size'      => $chunks[5],
                 'mtime'     => $date,
@@ -100,7 +100,7 @@ class BSDTarOutputParser implements ParserInterface
             return null;
         }
 
-        list($name, $version) = explode(' ', $output, 3);
+        list(, $version) = explode(' ', $output, 3);
 
         return $version;
     }
@@ -110,6 +110,6 @@ class BSDTarOutputParser implements ParserInterface
      */
     public function parseDeflatorVersion($output)
     {
-        return $this->parseInflatoVersion($output);
+        return $this->parseInflatorVersion($output);
     }
 }

--- a/src/Parser/GNUTarOutputParser.php
+++ b/src/Parser/GNUTarOutputParser.php
@@ -17,12 +17,12 @@ use Alchemy\Zippy\Exception\RuntimeException;
  */
 class GNUTarOutputParser implements ParserInterface
 {
-    const PERMISSIONS   = "([ldrwx-]+)";
-    const OWNER         = "([a-z][-a-z0-9]*)";
-    const GROUP         = "([a-z][-a-z0-9]*)";
-    const FILESIZE      = "(\d*)";
-    const ISO_DATE      = "([0-9]+-[0-9]+-[0-9]+\s+[0-9]+:[0-9]+)";
-    const FILENAME      = "(.*)";
+    const PERMISSIONS   = '([ldrwx-]+)';
+    const OWNER         = '([a-z][-a-z0-9]*)';
+    const GROUP         = '([a-z][-a-z0-9]*)';
+    const FILESIZE      = '(\d*)';
+    const ISO_DATE      = '([0-9]+-[0-9]+-[0-9]+\s+[0-9]+:[0-9]+)';
+    const FILENAME      = '(.*)';
 
     /**
      * @inheritdoc
@@ -83,7 +83,7 @@ class GNUTarOutputParser implements ParserInterface
             return null;
         }
 
-        list($name, $version) = $chunks;
+        list(, $version) = $chunks;
 
         return $version;
     }
@@ -93,6 +93,6 @@ class GNUTarOutputParser implements ParserInterface
      */
     public function parseDeflatorVersion($output)
     {
-        return $this->parseInflatoVersion($output);
+        return $this->parseInflatorVersion($output);
     }
 }

--- a/src/Parser/ParserInterface.php
+++ b/src/Parser/ParserInterface.php
@@ -18,9 +18,9 @@ interface ParserInterface
     /**
      * Parses a file listing
      *
-     * @param String $output The string to parse
+     * @param string $output The string to parse
      *
-     * @return Array An array of Member properties (location, mtime, size & is_dir)
+     * @return array An array of Member properties (location, mtime, size & is_dir)
      *
      * @throws RuntimeException In case the parsing process failed
      */
@@ -29,18 +29,18 @@ interface ParserInterface
     /**
      * Parses the inflator binary version
      *
-     * @param String $output
+     * @param string $output
      *
-     * @return String The version
+     * @return string The version
      */
     public function parseInflatorVersion($output);
 
     /**
      * Parses the deflator binary version
      *
-     * @param String $output
+     * @param string $output
      *
-     * @return String The version
+     * @return string The version
      */
-    public function parsedeflatorVersion($output);
+    public function parseDeflatorVersion($output);
 }

--- a/src/Parser/ZipOutputParser.php
+++ b/src/Parser/ZipOutputParser.php
@@ -15,9 +15,9 @@ namespace Alchemy\Zippy\Parser;
  */
 class ZipOutputParser implements ParserInterface
 {
-    const LENGTH        = "(\d*)";
-    const ISO_DATE      = "([0-9]+-[0-9]+-[0-9]+\s+[0-9]+:[0-9]+)";
-    const FILENAME      = "(.*)";
+    const LENGTH        = '(\d*)';
+    const ISO_DATE      = '([0-9]+-[0-9]+-[0-9]+\s+[0-9]+:[0-9]+)';
+    const FILENAME      = '(.*)';
 
     /**
      * @var string
@@ -84,7 +84,7 @@ class ZipOutputParser implements ParserInterface
             return null;
         }
 
-        list($name, $version) = $chunks;
+        list(, $version) = $chunks;
 
         return $version;
     }
@@ -102,7 +102,7 @@ class ZipOutputParser implements ParserInterface
             return null;
         }
 
-        list($name, $version) = $chunks;
+        list(, $version) = $chunks;
 
         return $version;
     }

--- a/src/ProcessBuilder/ProcessBuilderFactory.php
+++ b/src/ProcessBuilder/ProcessBuilderFactory.php
@@ -19,14 +19,14 @@ class ProcessBuilderFactory implements ProcessBuilderFactoryInterface
     /**
      * The binary path
      *
-     * @var String
+     * @var string
      */
     protected $binary;
 
     /**
      * Constructor
      *
-     * @param String $binary The path to the binary
+     * @param string $binary The path to the binary
      *
      * @throws InvalidArgumentException In case binary path is invalid
      */

--- a/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
+++ b/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
@@ -11,31 +11,31 @@
 
 namespace Alchemy\Zippy\ProcessBuilder;
 
-use Symfony\Component\Process\ProcessBuilder;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Symfony\Component\Process\ProcessBuilder;
 
 interface ProcessBuilderFactoryInterface
 {
-        /**
-         * Returns a new instance of Symfony ProcessBuilder
-         *
-         * @return ProcessBuilder
-         *
-         * @throws InvalidArgumentException
-         */
+    /**
+     * Returns a new instance of Symfony ProcessBuilder
+     *
+     * @return ProcessBuilder
+     *
+     * @throws InvalidArgumentException
+     */
     public function create();
 
     /**
      * Returns the binary path
      *
-     * @return String
+     * @return string
      */
     public function getBinary();
 
     /**
      * Sets the binary path
      *
-     * @param String $binary A binary path
+     * @param string $binary A binary path
      *
      * @return ProcessBuilderFactoryInterface
      *

--- a/src/Resource/Reader/Guzzle/GuzzleReader.php
+++ b/src/Resource/Reader/Guzzle/GuzzleReader.php
@@ -2,7 +2,7 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Guzzle;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 use GuzzleHttp\ClientInterface;
 
@@ -19,10 +19,10 @@ class GuzzleReader implements ResourceReader
     private $resource;
 
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ZippyResource   $resource
      * @param ClientInterface $client
      */
-    public function __construct(Resource $resource, ClientInterface $client = null)
+    public function __construct(ZippyResource $resource, ClientInterface $client = null)
     {
         $this->resource = $resource;
         $this->client = $client;

--- a/src/Resource/Reader/Guzzle/GuzzleReaderFactory.php
+++ b/src/Resource/Reader/Guzzle/GuzzleReaderFactory.php
@@ -2,7 +2,7 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Guzzle;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use GuzzleHttp\Client;
@@ -25,11 +25,12 @@ class GuzzleReaderFactory implements ResourceReaderFactory
     }
 
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
-     * @param string $context
+     * @param ZippyResource $resource
+     * @param string        $context
+     *
      * @return ResourceReader
      */
-    public function getReader(Resource $resource, $context)
+    public function getReader(ZippyResource $resource, $context)
     {
         return new GuzzleReader($resource, $this->client);
     }

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReader.php
@@ -2,7 +2,7 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Guzzle;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 use Guzzle\Http\Client;
 use Guzzle\Http\ClientInterface;
@@ -28,10 +28,10 @@ class LegacyGuzzleReader implements ResourceReader
     private $stream = null;
 
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ZippyResource   $resource
      * @param ClientInterface $client
      */
-    public function __construct(Resource $resource, ClientInterface $client = null)
+    public function __construct(ZippyResource $resource, ClientInterface $client = null)
     {
         $this->client = $client ?: new Client();
         $this->resource = $resource;

--- a/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
+++ b/src/Resource/Reader/Guzzle/LegacyGuzzleReaderFactory.php
@@ -2,7 +2,7 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Guzzle;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use Guzzle\Http\Client;
@@ -35,11 +35,12 @@ class LegacyGuzzleReaderFactory implements ResourceReaderFactory
     }
 
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
-     * @param string $context
+     * @param ZippyResource $resource
+     * @param string        $context
+     *
      * @return ResourceReader
      */
-    public function getReader(Resource $resource, $context)
+    public function getReader(ZippyResource $resource, $context)
     {
         return new LegacyGuzzleReader($resource, $this->client);
     }

--- a/src/Resource/Reader/Stream/StreamReader.php
+++ b/src/Resource/Reader/Stream/StreamReader.php
@@ -2,20 +2,20 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Stream;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 
 class StreamReader implements ResourceReader
 {
     /**
-     * @var \Alchemy\Zippy\Resource\Resource
+     * @var ZippyResource
      */
     private $resource;
 
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ZippyResource $resource
      */
-    public function __construct(Resource $resource)
+    public function __construct(ZippyResource $resource)
     {
         $this->resource = $resource;
     }

--- a/src/Resource/Reader/Stream/StreamReaderFactory.php
+++ b/src/Resource/Reader/Stream/StreamReaderFactory.php
@@ -2,19 +2,19 @@
 
 namespace Alchemy\Zippy\Resource\Reader\Stream;
 
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceReader;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 
 class StreamReaderFactory implements ResourceReaderFactory
 {
-
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
-     * @param string $context
+     * @param ZippyResource $resource
+     * @param string        $context
+     *
      * @return ResourceReader
      */
-    public function getReader(Resource $resource, $context)
+    public function getReader(ZippyResource $resource, $context)
     {
         return new StreamReader($resource);
     }

--- a/src/Resource/RequestMapper.php
+++ b/src/Resource/RequestMapper.php
@@ -28,6 +28,9 @@ class RequestMapper
     /**
      * Maps resources request to a ResourceCollection
      *
+     * @param       $context
+     * @param array $resources
+     *
      * @return ResourceCollection
      */
     public function map($context, array $resources)

--- a/src/Resource/Resource.php
+++ b/src/Resource/Resource.php
@@ -19,8 +19,8 @@ class Resource
     /**
      * Constructor
      *
-     * @param String $original
-     * @param String $target
+     * @param string $original
+     * @param string $target
      */
     public function __construct($original, $target)
     {
@@ -31,7 +31,7 @@ class Resource
     /**
      * Returns the target
      *
-     * @return String
+     * @return string
      */
     public function getTarget()
     {
@@ -41,7 +41,7 @@ class Resource
     /**
      * Returns the original path
      *
-     * @return String
+     * @return string
      */
     public function getOriginal()
     {
@@ -55,9 +55,9 @@ class Resource
      *   - /path/to/file1 can be processed to file1 in /path/to context
      *   - /path/to/subdir/file2 can be processed to subdir/file2 in /path/to context
      *
-     * @param String $context
+     * @param string $context
      *
-     * @return Boolean
+     * @return bool
      */
     public function canBeProcessedInPlace($context)
     {
@@ -90,12 +90,14 @@ class Resource
         if (PathUtil::basename($this->original) === $this->target) {
             return dirname($this->original);
         }
+        
+        return null;
     }
 
     /**
      * Returns true if the resource is local.
      *
-     * @return Boolean
+     * @return bool
      */
     private function isLocal()
     {

--- a/src/Resource/ResourceCollection.php
+++ b/src/Resource/ResourceCollection.php
@@ -17,13 +17,16 @@ use Doctrine\Common\Collections\ArrayCollection;
 class ResourceCollection extends ArrayCollection
 {
     private $context;
+    /**
+     * @var bool
+     */
     private $temporary;
 
     /**
      * Constructor
-     *
-     * @param String     $context
+     * @param string $context
      * @param Resource[] $elements An array of Resource
+     * @param bool $temporary
      */
     public function __construct($context, array $elements, $temporary)
     {
@@ -34,14 +37,14 @@ class ResourceCollection extends ArrayCollection
         });
 
         $this->context = $context;
-        $this->temporary = (Boolean) $temporary;
+        $this->temporary = (bool) $temporary;
         parent::__construct($elements);
     }
 
     /**
      * Returns the context related to the collection
      *
-     * @return String
+     * @return string
      */
     public function getContext()
     {
@@ -54,7 +57,7 @@ class ResourceCollection extends ArrayCollection
      * A ResourceCollection is temporary when it required a temporary folder to
      * fetch data
      *
-     * @return type
+     * @return bool
      */
     public function isTemporary()
     {
@@ -64,7 +67,7 @@ class ResourceCollection extends ArrayCollection
     /**
      * Returns true if all resources can be processed in place, false otherwise
      *
-     * @return Boolean
+     * @return bool
      */
     public function canBeProcessedInPlace()
     {

--- a/src/Resource/ResourceLocator.php
+++ b/src/Resource/ResourceLocator.php
@@ -2,9 +2,11 @@
 
 namespace Alchemy\Zippy\Resource;
 
+use Alchemy\Zippy\Resource\Resource AS ZippyResource;
+
 class ResourceLocator
 {
-    public function mapResourcePath(Resource $resource, $context)
+    public function mapResourcePath(ZippyResource $resource, $context)
     {
         return rtrim($context, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $resource->getTarget();
     }

--- a/src/Resource/ResourceManager.php
+++ b/src/Resource/ResourceManager.php
@@ -43,8 +43,8 @@ class ResourceManager
      * Some keys can be associative. In these cases, the key is used the target
      * for the file.
      *
-     * @param String $context
-     * @param Array  $request
+     * @param string $context
+     * @param array  $request
      *
      * @return ResourceCollection
      *

--- a/src/Resource/ResourceReaderFactory.php
+++ b/src/Resource/ResourceReaderFactory.php
@@ -2,13 +2,15 @@
 
 namespace Alchemy\Zippy\Resource;
 
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
+
 interface ResourceReaderFactory
 {
-
     /**
-     * @param \Alchemy\Zippy\Resource\Resource $resource
-     * @param string $context
+     * @param ZippyResource $resource
+     * @param string        $context
+     *
      * @return ResourceReader
      */
-    public function getReader(Resource $resource, $context);
+    public function getReader(ZippyResource $resource, $context);
 }

--- a/src/Resource/ResourceTeleporter.php
+++ b/src/Resource/ResourceTeleporter.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Zippy.
  *
@@ -8,8 +7,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace Alchemy\Zippy\Resource;
+
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 
 class ResourceTeleporter
 {
@@ -28,12 +28,12 @@ class ResourceTeleporter
     /**
      * Teleports a resource to its target in the context
      *
-     * @param string $context
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string        $context
+     * @param ZippyResource $resource
      *
      * @return ResourceTeleporter
      */
-    public function teleport($context, Resource $resource)
+    public function teleport($context, ZippyResource $resource)
     {
         $this
             ->container

--- a/src/Resource/TargetLocator.php
+++ b/src/Resource/TargetLocator.php
@@ -21,7 +21,7 @@ class TargetLocator
      * For example, adding /path/to/file where the context (current working
      * directory) is /path/to will return `file` as target
      *
-     * @param string $context
+     * @param string          $context
      * @param string|resource $resource
      *
      * @return string
@@ -36,7 +36,7 @@ class TargetLocator
             case is_string($resource):
                 return $this->locateString($context, $resource);
             case $resource instanceof \SplFileInfo:
-                return $this->locateString($context, $resource->getRealpath());
+                return $this->locateString($context, $resource->getRealPath());
             default:
                 throw new TargetLocatorException($resource, 'Unknown resource format');
         }
@@ -47,7 +47,7 @@ class TargetLocator
      *
      * @param resource $resource
      *
-     * @return String
+     * @return string
      *
      * @throws TargetLocatorException
      */
@@ -66,9 +66,10 @@ class TargetLocator
     /**
      * Locate the target for a string.
      *
-     * @param String $resource
+     * @param        $context
+     * @param string $resource
      *
-     * @return String
+     * @return string
      *
      * @throws TargetLocatorException
      */
@@ -102,9 +103,9 @@ class TargetLocator
     /**
      * Removes backward path sequences (..)
      *
-     * @param String $path
+     * @param string $path
      *
-     * @return String
+     * @return string
      *
      * @throws TargetLocatorException In case the path is invalid
      */
@@ -120,8 +121,9 @@ class TargetLocator
     /**
      * Checks whether the path belong to the context
      *
-     * @param string $path    A resource path
+     * @param string $path A resource path
      * @param string $context
+     *
      * @return bool
      */
     private function isFileInContext($path, $context)
@@ -134,6 +136,7 @@ class TargetLocator
      *
      * @param string $path A resource path
      * @param string $context
+     *
      * @return string
      */
     private function getRelativePathFromContext($path, $context)
@@ -145,6 +148,7 @@ class TargetLocator
      * Checks if a scheme refers to a local filesystem
      *
      * @param string $scheme
+     *
      * @return bool
      */
     private function isLocalFilesystem($scheme)

--- a/src/Resource/Teleporter/AbstractTeleporter.php
+++ b/src/Resource/Teleporter/AbstractTeleporter.php
@@ -11,8 +11,8 @@
 
 namespace Alchemy\Zippy\Resource\Teleporter;
 
-use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Exception\IOException;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 
 /**
  * Class AbstractTeleporter
@@ -25,15 +25,15 @@ abstract class AbstractTeleporter implements TeleporterInterface
     /**
      * Writes the target
      *
-     * @param string $data
-     * @param \Alchemy\Zippy\Resource\Resource $resource
-     * @param string $context
+     * @param string        $data
+     * @param ZippyResource $resource
+     * @param string        $context
      *
      * @return TeleporterInterface
      *
      * @throws IOException
      */
-    protected function writeTarget($data, Resource $resource, $context)
+    protected function writeTarget($data, ZippyResource $resource, $context)
     {
         $target = $this->getTarget($context, $resource);
 
@@ -51,12 +51,12 @@ abstract class AbstractTeleporter implements TeleporterInterface
     /**
      * Returns the relative target of a Resource
      *
-     * @param String   $context
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param string        $context
+     * @param ZippyResource $resource
      *
-     * @return String
+     * @return string
      */
-    protected function getTarget($context, Resource $resource)
+    protected function getTarget($context, ZippyResource $resource)
     {
         return sprintf('%s/%s', rtrim($context, '/'), $resource->getTarget());
     }

--- a/src/Resource/Teleporter/GenericTeleporter.php
+++ b/src/Resource/Teleporter/GenericTeleporter.php
@@ -4,7 +4,7 @@ namespace Alchemy\Zippy\Resource\Teleporter;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\IOException;
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceLocator;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use Alchemy\Zippy\Resource\ResourceWriter;
@@ -28,8 +28,8 @@ class GenericTeleporter implements TeleporterInterface
 
     /**
      * @param ResourceReaderFactory $readerFactory
-     * @param ResourceWriter $resourceWriter
-     * @param ResourceLocator $resourceLocator
+     * @param ResourceWriter        $resourceWriter
+     * @param ResourceLocator       $resourceLocator
      */
     public function __construct(
         ResourceReaderFactory $readerFactory,
@@ -44,13 +44,13 @@ class GenericTeleporter implements TeleporterInterface
     /**
      * Teleports a file from a destination to an other
      *
-     * @param \Alchemy\Zippy\Resource\Resource $resource A Resource
-     * @param string $context The current context
+     * @param ZippyResource $resource A Resource
+     * @param string        $context  The current context
      *
      * @throws IOException when file could not be written on local
      * @throws InvalidArgumentException when path to file is not valid
      */
-    public function teleport(Resource $resource, $context)
+    public function teleport(ZippyResource $resource, $context)
     {
         $reader = $this->readerFactory->getReader($resource, $context);
         $target = $this->resourceLocator->mapResourcePath($resource, $context);

--- a/src/Resource/Teleporter/LegacyGuzzleTeleporter.php
+++ b/src/Resource/Teleporter/LegacyGuzzleTeleporter.php
@@ -15,12 +15,12 @@ use Alchemy\Zippy\Resource\Reader\Guzzle\LegacyGuzzleReaderFactory;
 use Alchemy\Zippy\Resource\ResourceLocator;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use Alchemy\Zippy\Resource\Writer\FilesystemWriter;
-use GuzzleHttp\Client;
+use Guzzle\Http\Client;
 
 /**
  * Guzzle Teleporter implementation for HTTP resources
  */
-class GuzzleTeleporter extends GenericTeleporter
+class LegacyGuzzleTeleporter extends GenericTeleporter
 {
     /**
      * @param Client $client
@@ -40,7 +40,7 @@ class GuzzleTeleporter extends GenericTeleporter
      * Creates the GuzzleTeleporter
      *
      * @deprecated
-     * @return GuzzleTeleporter
+     * @return LegacyGuzzleTeleporter
      */
     public static function create()
     {

--- a/src/Resource/Teleporter/LocalTeleporter.php
+++ b/src/Resource/Teleporter/LocalTeleporter.php
@@ -11,12 +11,12 @@
 
 namespace Alchemy\Zippy\Resource\Teleporter;
 
-use Alchemy\Zippy\Resource\Resource;
-use Alchemy\Zippy\Exception\IOException;
 use Alchemy\Zippy\Exception\InvalidArgumentException;
+use Alchemy\Zippy\Exception\IOException;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\ResourceLocator;
-use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\Filesystem\Exception\IOException as SfIOException;
+use Symfony\Component\Filesystem\Filesystem;
 
 /**
  * This class transport an object using the local filesystem
@@ -47,7 +47,7 @@ class LocalTeleporter extends AbstractTeleporter
     /**
      * {@inheritdoc}
      */
-    public function teleport(Resource $resource, $context)
+    public function teleport(ZippyResource $resource, $context)
     {
         $target = $this->resourceLocator->mapResourcePath($resource, $context);
         $path = $resource->getOriginal();

--- a/src/Resource/Teleporter/TeleporterInterface.php
+++ b/src/Resource/Teleporter/TeleporterInterface.php
@@ -13,18 +13,18 @@ namespace Alchemy\Zippy\Resource\Teleporter;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Exception\IOException;
-use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 
 interface TeleporterInterface
 {
     /**
      * Teleports a file from a destination to an other
      *
-     * @param \Alchemy\Zippy\Resource\Resource $resource A Resource
-     * @param string $context The current context
+     * @param ZippyResource $resource A Resource
+     * @param string        $context  The current context
      *
      * @throws IOException when file could not be written on local
      * @throws InvalidArgumentException when path to file is not valid
      */
-    public function teleport(Resource $resource, $context);
+    public function teleport(ZippyResource $resource, $context);
 }

--- a/src/Resource/TeleporterContainer.php
+++ b/src/Resource/TeleporterContainer.php
@@ -13,8 +13,9 @@ namespace Alchemy\Zippy\Resource;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
 use Alchemy\Zippy\Resource\Reader\Guzzle\GuzzleReaderFactory;
-use Alchemy\Zippy\Resource\Teleporter\LocalTeleporter;
+use Alchemy\Zippy\Resource\Resource as ZippyResource;
 use Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter;
+use Alchemy\Zippy\Resource\Teleporter\LocalTeleporter;
 use Alchemy\Zippy\Resource\Teleporter\StreamTeleporter;
 use Alchemy\Zippy\Resource\Teleporter\TeleporterInterface;
 
@@ -36,10 +37,11 @@ class TeleporterContainer implements \ArrayAccess, \Countable
     /**
      * Returns the appropriate TeleporterInterface for a given Resource
      *
-     * @param \Alchemy\Zippy\Resource\Resource $resource
+     * @param ZippyResource $resource
+     *
      * @return TeleporterInterface
      */
-    public function fromResource(Resource $resource)
+    public function fromResource(ZippyResource $resource)
     {
         switch (true) {
             case is_resource($resource->getOriginal()):
@@ -111,11 +113,14 @@ class TeleporterContainer implements \ArrayAccess, \Countable
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Whether a offset exists
+     *
      * @link http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
      * @param mixed $offset <p>
-     * An offset to check for.
-     * </p>
-     * @return boolean true on success or false on failure.
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return bool true on success or false on failure.
      * </p>
      * <p>
      * The return value will be casted to boolean if non-boolean was returned.

--- a/src/Zippy.php
+++ b/src/Zippy.php
@@ -11,16 +11,16 @@
 
 namespace Alchemy\Zippy;
 
-use Alchemy\Zippy\Adapter\AdapterInterface;
 use Alchemy\Zippy\Adapter\AdapterContainer;
+use Alchemy\Zippy\Adapter\AdapterInterface;
 use Alchemy\Zippy\Archive\ArchiveInterface;
 use Alchemy\Zippy\Exception\ExceptionInterface;
 use Alchemy\Zippy\Exception\FormatNotSupportedException;
 use Alchemy\Zippy\Exception\NoAdapterOnPlatformException;
 use Alchemy\Zippy\Exception\RuntimeException;
 use Alchemy\Zippy\FileStrategy\FileStrategyInterface;
-use Alchemy\Zippy\FileStrategy\TarFileStrategy;
 use Alchemy\Zippy\FileStrategy\TarBz2FileStrategy;
+use Alchemy\Zippy\FileStrategy\TarFileStrategy;
 use Alchemy\Zippy\FileStrategy\TarGzFileStrategy;
 use Alchemy\Zippy\FileStrategy\TB2FileStrategy;
 use Alchemy\Zippy\FileStrategy\TBz2FileStrategy;
@@ -48,8 +48,8 @@ class Zippy
      * Creates an archive
      *
      * @param string                         $path
-     * @param String|Array|\Traversable|null $files
-     * @param Boolean                        $recursive
+     * @param string|array|\Traversable|null $files
+     * @param bool                           $recursive
      * @param string|null                    $type
      *
      * @return ArchiveInterface

--- a/tests/Tests/Adapter/Resource/FileResourceTest.php
+++ b/tests/Tests/Adapter/Resource/FileResourceTest.php
@@ -12,6 +12,6 @@ class FileResourceTest extends TestCase
         $path = '/path/to/resource';
         $resource = new FileResource($path);
 
-        $this->asserTEquals($path, $resource->getResource());
+        $this->assertEquals($path, $resource->getResource());
     }
 }

--- a/tests/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/GuzzleTeleporterTest.php
@@ -24,7 +24,7 @@ class GuzzleTeleporterTest extends TeleporterTestCase
 
         $teleporter->teleport($resource, $context);
 
-        $this->assertfileExists($context . '/' . $target);
+        $this->assertFileExists($context . '/' . $target);
         unlink($context . '/' . $target);
     }
 

--- a/tests/Tests/Resource/Teleporter/LocalTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/LocalTeleporterTest.php
@@ -24,7 +24,7 @@ class LocalTeleporterTest extends TeleporterTestCase
 
         $teleporter->teleport($resource, $context);
 
-        $this->assertfileExists($context . '/' . $target);
+        $this->assertFileExists($context . '/' . $target);
         unlink($context . '/' . $target);
     }
 
@@ -45,7 +45,7 @@ class LocalTeleporterTest extends TeleporterTestCase
 
         $teleporter->teleport($resource, $context);
 
-        $this->assertfileExists($context . '/' . $target);
+        $this->assertFileExists($context . '/' . $target);
         unlink($context . '/' . $target);
     }
 

--- a/tests/Tests/Resource/Teleporter/StreamTeleporterTest.php
+++ b/tests/Tests/Resource/Teleporter/StreamTeleporterTest.php
@@ -24,7 +24,7 @@ class StreamTeleporterTest extends TeleporterTestCase
 
         $teleporter->teleport($resource, $context);
 
-        $this->assertfileExists($context . '/' . $target);
+        $this->assertFileExists($context . '/' . $target);
         unlink($context . '/' . $target);
     }
 
@@ -45,7 +45,7 @@ class StreamTeleporterTest extends TeleporterTestCase
 
         $teleporter->teleport($resource, $context);
 
-        $this->assertfileExists($context . '/' . $target);
+        $this->assertFileExists($context . '/' . $target);
         unlink($context . '/' . $target);
     }
 


### PR DESCRIPTION
- Fixes #106 and other PHPDoc problems  …
- Created ZippyResource synonyms for Alchemy\Zippy\Resource\Resource. Resource class should be renamed totally #107
- GuzzleTeleporter was using Guzzle\Http created a copy as LegacyGuzzleTeleporter to match GuzzleReader and LegacyGuzzleReader