### PR TITLE
Fix parse_url expects string, resource given error

### DIFF
--- a/src/Resource/Resource.php
+++ b/src/Resource/Resource.php
@@ -83,6 +83,10 @@ class Resource
      */
     public function getContextForProcessInSinglePlace()
     {
+        if (!is_string($this->original)) {
+            return null;
+        }
+
         if (!$this->isLocal()) {
             return null;
         }
@@ -101,6 +105,10 @@ class Resource
      */
     private function isLocal()
     {
+        if (!is_string($this->original)) {
+            return false;
+        }
+
         $data = parse_url($this->original);
 
         return isset($data['path']);

--- a/tests/Tests/Resource/ResourceTest.php
+++ b/tests/Tests/Resource/ResourceTest.php
@@ -30,9 +30,19 @@ class ResourceTest extends TestCase
     public function testCanBeProcessedInPlace($expected, $context, $original, $target)
     {
         $resource = new Resource($original, $target);
+        $result = $resource->canBeProcessedInPlace($context);
 
-        $this->assertInternalType('boolean', $resource->canBeProcessedInPlace($context));
-        $this->assertEquals($expected, $resource->canBeProcessedInPlace($context));
+        $this->assertInternalType('boolean', $result);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function testGetContextForProcessInSinglePlace()
+    {
+        $resource = new Resource(fopen(__FILE__, 'rb'), 'file1');
+        $this->assertNull($resource->getContextForProcessInSinglePlace());
+
+        $resource = new Resource('/path/to/file1', 'file1');
+        $this->assertEquals('/path/to', $resource->getContextForProcessInSinglePlace());
     }
 
     public function provideProcessInPlaceData()


### PR DESCRIPTION
When I work with resources, I got the error: Warning: parse_url() expects string, resource given.