### PR TITLE
Clean up teleporters and tests

### DIFF
--- a/src/Resource/Teleporter/AbstractTeleporter.php
+++ b/src/Resource/Teleporter/AbstractTeleporter.php
@@ -18,7 +18,8 @@ use Alchemy\Zippy\Resource\Resource as ZippyResource;
  * Class AbstractTeleporter
  * @package Alchemy\Zippy\Resource\Teleporter
  *
- * @deprecated Typehint against TeleporterInterface instead and use GenericTeleporter with custom reader/writers instead.
+ * @deprecated Typehint against TeleporterInterface instead and use GenericTeleporter
+*  with custom reader/writers instead. This class will be removed in v0.5.x
  */
 abstract class AbstractTeleporter implements TeleporterInterface
 {

--- a/src/Resource/Teleporter/GuzzleTeleporter.php
+++ b/src/Resource/Teleporter/GuzzleTeleporter.php
@@ -11,35 +11,31 @@
 
 namespace Alchemy\Zippy\Resource\Teleporter;
 
-use Alchemy\Zippy\Resource\Reader\Guzzle\LegacyGuzzleReaderFactory;
+use Alchemy\Zippy\Resource\Reader\Guzzle\GuzzleReaderFactory;
 use Alchemy\Zippy\Resource\ResourceLocator;
 use Alchemy\Zippy\Resource\ResourceReaderFactory;
 use Alchemy\Zippy\Resource\Writer\FilesystemWriter;
-use GuzzleHttp\Client;
 
 /**
  * Guzzle Teleporter implementation for HTTP resources
+ *
+ * @deprecated Use \Alchemy\Zippy\Resource\GenericTeleporter instead. This class will be removed in v0.5.x
  */
 class GuzzleTeleporter extends GenericTeleporter
 {
     /**
-     * @param Client $client
      * @param ResourceReaderFactory $readerFactory
      * @param ResourceLocator $resourceLocator
      */
-    public function __construct(
-        Client $client = null,
-        ResourceReaderFactory $readerFactory = null,
-        ResourceLocator $resourceLocator = null
-    ) {
-        parent::__construct($readerFactory ?: new LegacyGuzzleReaderFactory($client), new FilesystemWriter(),
-            $resourceLocator);
+    public function __construct(ResourceReaderFactory $readerFactory = null, ResourceLocator $resourceLocator = null)
+    {
+        parent::__construct($readerFactory ?: new GuzzleReaderFactory(), new FilesystemWriter(), $resourceLocator);
     }
 
     /**
      * Creates the GuzzleTeleporter
      *
-     * @deprecated
+     * @deprecated This method will be removed in v0.5.x
      * @return GuzzleTeleporter
      */
     public static function create()

--- a/src/Resource/Teleporter/LegacyGuzzleTeleporter.php
+++ b/src/Resource/Teleporter/LegacyGuzzleTeleporter.php
@@ -19,6 +19,8 @@ use Guzzle\Http\Client;
 
 /**
  * Guzzle Teleporter implementation for HTTP resources
+ *
+ * @deprecated Use \Alchemy\Zippy\Resource\GenericTeleporter instead. This class will be removed in v0.5.x
  */
 class LegacyGuzzleTeleporter extends GenericTeleporter
 {

--- a/src/Resource/Teleporter/LocalTeleporter.php
+++ b/src/Resource/Teleporter/LocalTeleporter.php
@@ -19,7 +19,7 @@ use Symfony\Component\Filesystem\Exception\IOException as SfIOException;
 use Symfony\Component\Filesystem\Filesystem;
 
 /**
- * This class transport an object using the local filesystem
+ * This class transports an object using the local filesystem
  */
 class LocalTeleporter extends AbstractTeleporter
 {
@@ -73,6 +73,7 @@ class LocalTeleporter extends AbstractTeleporter
      * Creates the LocalTeleporter
      *
      * @return LocalTeleporter
+     * @deprecated This method will be removed in a future release (0.5.x)
      */
     public static function create()
     {

--- a/src/Resource/Teleporter/StreamTeleporter.php
+++ b/src/Resource/Teleporter/StreamTeleporter.php
@@ -29,6 +29,7 @@ class StreamTeleporter extends GenericTeleporter
      * Creates the StreamTeleporter
      *
      * @return StreamTeleporter
+     * @deprecated This method will be removed in a future release (0.5.x)
      */
     public static function create()
     {

--- a/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
@@ -40,7 +40,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $classname = static::getAdapterClassName();
 
-        $inflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                 ->disableOriginalConstructor()
                 ->setMethods(array('useBinary'))
                 ->getMock();
@@ -71,19 +71,26 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     public function testNewinstance()
     {
         $classname = static::getAdapterClassName();
-        $finder = $this->getMockBuilder('Symfony\Component\Process\ExecutableFinder')
+        $finder = $this->getMockBuilder('\Symfony\Component\Process\ExecutableFinder')
             ->disableOriginalConstructor()
             ->getMock();
-        $manager = $this->getMockBuilder('Alchemy\Zippy\Resource\ResourceManager')
+        $manager = $this->getMockBuilder('\Alchemy\Zippy\Resource\ResourceManager')
             ->disableOriginalConstructor()
             ->getMock();
-        $instance = $classname::newInstance($finder, $manager, $this->getMock('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface'), $this->getMock('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface'));
+
+        $instance = $classname::newInstance(
+            $finder,
+            $manager,
+            $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface')->getMock(),
+            $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface')->getMock()
+        );
+
         $this->assertInstanceOf($classname, $instance);
     }
 
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -135,7 +142,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testCreate()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -198,7 +205,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -243,7 +250,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testgetVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -265,7 +272,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -301,7 +308,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -359,7 +366,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -396,7 +403,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $archiveFileMock = $this->getMock('Alchemy\Zippy\Archive\MemberInterface');
+        $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
         $archiveFileMock
             ->expects($this->any())
             ->method('getLocation')

--- a/tests/Tests/Adapter/BSDTar/TarBSDTarAdapterTest.php
+++ b/tests/Tests/Adapter/BSDTar/TarBSDTarAdapterTest.php
@@ -38,7 +38,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
 
     private function provideAdapter()
     {
-        $inflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                 ->disableOriginalConstructor()
                 ->setMethods(array('useBinary'))
                 ->getMock();
@@ -68,8 +68,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
 
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
-
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -117,7 +116,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $outputParser = ParserFactory::create(TarBSDTarAdapter::getName());
         $manager = $this->getResourceManagerMock(__DIR__, array('lalalalala'));
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -169,7 +168,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -203,7 +202,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -229,7 +228,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
 
     public function testgetVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -251,7 +250,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -281,7 +280,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -333,7 +332,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -364,7 +363,7 @@ class TarBSDTarAdapterTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $archiveFileMock = $this->getMock('Alchemy\Zippy\Archive\MemberInterface');
+        $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
 
         $archiveFileMock
             ->expects($this->any())

--- a/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
@@ -40,7 +40,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $classname = static::getAdapterClassName();
 
-        $inflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                 ->disableOriginalConstructor()
                 ->setMethods(array('useBinary'))
                 ->getMock();
@@ -70,7 +70,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
 
         $mockedProcessBuilder
@@ -123,7 +123,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testCreate()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -181,7 +181,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -232,7 +232,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testgetVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -254,7 +254,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -296,7 +296,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -366,7 +366,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -403,7 +403,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $archiveFileMock = $this->getMock('Alchemy\Zippy\Archive\MemberInterface');
+        $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
 
         $archiveFileMock
             ->expects($this->any())

--- a/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
+++ b/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
@@ -38,7 +38,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
 
     private function provideAdapter()
     {
-        $inflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                 ->disableOriginalConstructor()
                 ->setMethods(array('useBinary'))
                 ->getMock();
@@ -68,7 +68,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
 
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
 
         $mockedProcessBuilder
@@ -115,7 +115,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
 
     public function testCreate()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -165,7 +165,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -205,7 +205,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -231,7 +231,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
 
     public function testgetVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -253,7 +253,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -295,7 +295,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -359,7 +359,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -390,7 +390,7 @@ class TarGNUTarAdapterTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $archiveFileMock = $this->getMock('Alchemy\Zippy\Archive\MemberInterface');
+        $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
 
         $archiveFileMock
             ->expects($this->any())

--- a/tests/Tests/Adapter/VersionProbe/AbstractTarVersionProbeTest.php
+++ b/tests/Tests/Adapter/VersionProbe/AbstractTarVersionProbeTest.php
@@ -56,7 +56,7 @@ abstract class AbstractTarVersionProbeTest extends TestCase
 
     protected function getBuilder($version, $call = true)
     {
-        $mock = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mock = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockBuilder = $mock
             ->expects($call ? $this->once() : $this->never())

--- a/tests/Tests/Adapter/VersionProbe/ZipVersionProbeTest.php
+++ b/tests/Tests/Adapter/VersionProbe/ZipVersionProbeTest.php
@@ -13,7 +13,7 @@ class ZipVersionProbeTest extends TestCase
      */
     public function testGetStatusIsOk()
     {
-        $mockedProcessBuilderInflator = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilderInflator = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilderInflator
             ->expects($this->once())
@@ -50,7 +50,7 @@ zip [-options] [-b path] [-t mmddyyyy] [-n suffixes] [zipfile list] [-xi list]
   -e   encrypt                      -n   don\'t compress these suffixes
   -h2  show more help'));
 
-        $mockedProcessBuilderDeflator = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilderDeflator = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilderDeflator
             ->expects($this->once())
@@ -100,7 +100,7 @@ Examples (see unzip.txt for more info):
      */
     public function testGetStatusIsNotOk()
     {
-        $mockedProcessBuilderInflator = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilderInflator = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilderInflator
             ->expects($this->once())
@@ -117,7 +117,7 @@ Examples (see unzip.txt for more info):
             ->method('getOutput')
             ->will($this->returnValue('bsdtar 2.8.3 - libarchive 2.8.3'));
 
-        $mockedProcessBuilderDeflator = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilderDeflator = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilderDeflator
             ->expects($this->once())

--- a/tests/Tests/Adapter/ZipAdapterTest.php
+++ b/tests/Tests/Adapter/ZipAdapterTest.php
@@ -37,7 +37,7 @@ class ZipAdapterTest extends AdapterTestCase
 
     protected function provideNotSupportedAdapter()
     {
-        $inflator = $deflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $deflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                                     ->disableOriginalConstructor()
                                     ->setMethods(array('useBinary'))
                                     ->getMock();
@@ -52,7 +52,7 @@ class ZipAdapterTest extends AdapterTestCase
 
     protected function provideSupportedAdapter()
     {
-        $inflator = $deflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $inflator = $deflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                                     ->disableOriginalConstructor()
                                     ->setMethods(array('useBinary'))
                                     ->getMock();
@@ -66,11 +66,11 @@ class ZipAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException Alchemy\Zippy\Exception\NotSupportedException
+     * @expectedException \Alchemy\Zippy\Exception\NotSupportedException
      */
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
 
@@ -79,7 +79,7 @@ class ZipAdapterTest extends AdapterTestCase
 
     public function testCreate()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -111,7 +111,7 @@ class ZipAdapterTest extends AdapterTestCase
 
         $manager = $this->getResourceManagerMock(__DIR__, array('lalala'));
         $outputParser = ParserFactory::create(ZipAdapter::getName());
-        $deflator = $this->getMockBuilder('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
+        $deflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
                                     ->disableOriginalConstructor()
                                     ->setMethods(array('useBinary'))
                                     ->getMock();
@@ -138,7 +138,7 @@ class ZipAdapterTest extends AdapterTestCase
         $resource = $this->getResource(self::$zipFile);
         $archive = $this->adapter->open($resource);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -166,7 +166,7 @@ class ZipAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$zipFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -198,7 +198,7 @@ class ZipAdapterTest extends AdapterTestCase
 
     public function testgetInflatorVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -211,7 +211,7 @@ class ZipAdapterTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $this->adapter->setParser($this->getMock('Alchemy\Zippy\Parser\ParserInterface'));
+        $this->adapter->setParser($this->getMockBuilder('\Alchemy\Zippy\Parser\ParserInterface')->getMock());
         $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
 
         $this->adapter->getInflatorVersion();
@@ -219,7 +219,7 @@ class ZipAdapterTest extends AdapterTestCase
 
     public function testgetDeflatorVersion()
     {
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -232,7 +232,7 @@ class ZipAdapterTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $this->adapter->setParser($this->getMock('Alchemy\Zippy\Parser\ParserInterface'));
+        $this->adapter->setParser($this->getMockBuilder('\Alchemy\Zippy\Parser\ParserInterface')->getMock());
         $this->adapter->setDeflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
 
         $this->adapter->getDeflatorVersion();
@@ -242,7 +242,7 @@ class ZipAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$zipFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -273,7 +273,7 @@ class ZipAdapterTest extends AdapterTestCase
             ->method('getProcess')
             ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
-        $archiveFileMock = $this->getMock('Alchemy\Zippy\Archive\MemberInterface');
+        $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
 
         $archiveFileMock
             ->expects($this->any())
@@ -292,7 +292,7 @@ class ZipAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$zipFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))
@@ -322,7 +322,7 @@ class ZipAdapterTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$zipFile);
 
-        $mockedProcessBuilder = $this->getMock('Symfony\Component\Process\ProcessBuilder');
+        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
 
         $mockedProcessBuilder
             ->expects($this->at(0))

--- a/tests/Tests/Archive/ArchiveTest.php
+++ b/tests/Tests/Archive/ArchiveTest.php
@@ -84,6 +84,6 @@ class ArchiveTest extends TestCase
 
     private function getAdapterMock()
     {
-        return $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+        return $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
     }
 }

--- a/tests/Tests/Archive/MemberTest.php
+++ b/tests/Tests/Archive/MemberTest.php
@@ -12,7 +12,7 @@ class MemberTest extends TestCase
     {
         $member = new Member(
             $this->getResource('archive/located/here'),
-             $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface'),
+             $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock(),
             'location',
             1233456,
             new \DateTime("2012-07-08 11:14:15"),
@@ -66,7 +66,7 @@ class MemberTest extends TestCase
 
     public function testExtract()
     {
-        $mockAdapter =  $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+        $mockAdapter =  $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
 
         $mockAdapter
             ->expects($this->any())

--- a/tests/Tests/FileStrategy/AbstractFileStrategyTest.php
+++ b/tests/Tests/FileStrategy/AbstractFileStrategyTest.php
@@ -50,8 +50,8 @@ class AbstractFileStrategyTest extends TestCase
 
     public function testGetAdaptersWithAdapterThatRaiseAnException()
     {
-        $adapterMock = $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
-        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $adapterMock = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterContainer')->getMock();
         $container
             ->expects($this->at(0))
             ->method('offsetGet')

--- a/tests/Tests/FileStrategy/FileStrategyTestCase.php
+++ b/tests/Tests/FileStrategy/FileStrategyTestCase.php
@@ -13,7 +13,7 @@ abstract class FileStrategyTestCase extends TestCase
     public function getFileExtensionShouldReturnAnString()
     {
         $that = $this;
-        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterContainer')->getMock();
         $container
                 ->expects($this->any())
                 ->method('offsetGet')
@@ -35,13 +35,13 @@ abstract class FileStrategyTestCase extends TestCase
     public function getAdaptersShouldReturnAnArrayOfAdapter()
     {
         $that = $this;
-        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterContainer')->getMock();
         $container
                 ->expects($this->any())
                 ->method('offsetGet')
                 ->will($this->returnCallback(function ($offset) use ($that) {
                     if (array_key_exists('Alchemy\Zippy\Adapter\AdapterInterface', class_implements($offset))) {
-                        return $that->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+                        return $that->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
                     }
 
                     return null;
@@ -59,7 +59,7 @@ abstract class FileStrategyTestCase extends TestCase
     /** @test */
     public function getAdaptersShouldReturnAnArrayOfAdapterEvenIfAdapterRaiseAnException()
     {
-        $container = $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterContainer')->getMock();
         $container
             ->expects($this->any())
             ->method('offsetGet')

--- a/tests/Tests/Resource/RequestMapperTest.php
+++ b/tests/Tests/Resource/RequestMapperTest.php
@@ -12,7 +12,7 @@ class RequestMapperTest extends TestCase
      */
     public function testMap()
     {
-        $locator = $this->getMockBuilder('Alchemy\Zippy\Resource\TargetLocator')
+        $locator = $this->getMockBuilder('\Alchemy\Zippy\Resource\TargetLocator')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Tests/Resource/ResourceCollectionTest.php
+++ b/tests/Tests/Resource/ResourceCollectionTest.php
@@ -30,7 +30,7 @@ class ResourceCollectionTest extends TestCase
 
     private function createResourceMock()
     {
-        return $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        return $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -63,7 +63,7 @@ class ResourceCollectionTest extends TestCase
 
     private function getInPlaceResource($processInPlace)
     {
-        $resource = $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Tests/Resource/ResourceManagerTest.php
+++ b/tests/Tests/Resource/ResourceManagerTest.php
@@ -63,7 +63,7 @@ class ResourceManagerTest extends TestCase
 
     private function createProcessableInPlaceResource()
     {
-        $resource = $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
         $resource->expects($this->any())
@@ -75,7 +75,7 @@ class ResourceManagerTest extends TestCase
 
     private function createNotProcessableInPlaceResource()
     {
-        $resource = $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
         $resource->expects($this->any())
@@ -104,7 +104,7 @@ class ResourceManagerTest extends TestCase
             ->method('remove')
             ->with($this->equalTo($context));
 
-        $collection = $this->getMockBuilder('Alchemy\Zippy\Resource\ResourceCollection')
+        $collection = $this->getMockBuilder('\Alchemy\Zippy\Resource\ResourceCollection')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -135,7 +135,7 @@ class ResourceManagerTest extends TestCase
         $fs->expects($this->never())
             ->method('remove');
 
-        $collection = $this->getMockBuilder('Alchemy\Zippy\Resource\ResourceCollection')
+        $collection = $this->getMockBuilder('\Alchemy\Zippy\Resource\ResourceCollection')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -220,21 +220,21 @@ class ResourceManagerTest extends TestCase
 
     protected function getRequestMapperMock()
     {
-        return $this->getMockBuilder('Alchemy\Zippy\Resource\RequestMapper')
+        return $this->getMockBuilder('\Alchemy\Zippy\Resource\RequestMapper')
             ->disableOriginalConstructor()
             ->getMock();
     }
 
     protected function getResourceTeleporterMock()
     {
-        return $this->getMockBuilder('Alchemy\Zippy\Resource\ResourceTeleporter')
+        return $this->getMockBuilder('\Alchemy\Zippy\Resource\ResourceTeleporter')
             ->disableOriginalConstructor()
             ->getMock();
     }
 
     protected function getFilesystemMock()
     {
-        return $this->getMockBuilder('Symfony\Component\Filesystem\Filesystem')
+        return $this->getMockBuilder('\Symfony\Component\Filesystem\Filesystem')
             ->disableOriginalConstructor()
             ->getMock();
     }

--- a/tests/Tests/Resource/ResourceTeleporterTest.php
+++ b/tests/Tests/Resource/ResourceTeleporterTest.php
@@ -12,7 +12,7 @@ class ResourceTeleporterTest extends TestCase
      */
     public function testConstruct()
     {
-        $container = $this->getMockBuilder('Alchemy\Zippy\Resource\TeleporterContainer')
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Resource\TeleporterContainer')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -27,15 +27,15 @@ class ResourceTeleporterTest extends TestCase
     public function testTeleport()
     {
         $context = 'supa-context';
-        $resource = $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $container = $this->getMockBuilder('Alchemy\Zippy\Resource\TeleporterContainer')
+        $container = $this->getMockBuilder('\Alchemy\Zippy\Resource\TeleporterContainer')
             ->disableOriginalConstructor()
             ->getMock();
 
-        $teleporter = $this->getMock('Alchemy\Zippy\Resource\Teleporter\TeleporterInterface');
+        $teleporter = $this->getMockBuilder('\Alchemy\Zippy\Resource\Teleporter\TeleporterInterface')->getMock();
         $teleporter->expects($this->once())
             ->method('teleport')
             ->with($this->equalTo($resource), $this->equalTo($context));

--- a/tests/Tests/Resource/TeleporterContainerTest.php
+++ b/tests/Tests/Resource/TeleporterContainerTest.php
@@ -8,7 +8,7 @@ use Alchemy\Zippy\Resource\TeleporterContainer;
 class TeleporterContainerTest extends TestCase
 {
     /**
-     * @covers Alchemy\Zippy\Resource\TeleporterContainer::fromResource
+     * @covers \Alchemy\Zippy\Resource\TeleporterContainer::fromResource
      * @dataProvider provideResourceData
      */
     public function testFromResource($resource, $classname)
@@ -18,8 +18,8 @@ class TeleporterContainerTest extends TestCase
         $this->assertInstanceOf($classname, $container->fromResource($resource));
     }
     /**
-     * @covers Alchemy\Zippy\Resource\TeleporterContainer::fromResource
-     * @expectedException Alchemy\Zippy\Exception\InvalidArgumentException
+     * @covers \Alchemy\Zippy\Resource\TeleporterContainer::fromResource
+     * @expectedException \Alchemy\Zippy\Exception\InvalidArgumentException
      */
     public function testFromResourceThatFails()
     {
@@ -33,13 +33,13 @@ class TeleporterContainerTest extends TestCase
             array($this->createResource(__FILE__), 'Alchemy\Zippy\Resource\Teleporter\LocalTeleporter'),
             array($this->createResource(fopen(__FILE__, 'rb')), 'Alchemy\Zippy\Resource\Teleporter\StreamTeleporter'),
             array($this->createResource('ftp://192.168.1.1/images/elephant.png'), 'Alchemy\Zippy\Resource\Teleporter\StreamTeleporter'),
-            array($this->createResource('http://127.0.0.1:8080/plus-badge.png'), 'Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter'),
+            array($this->createResource('http://127.0.0.1:8080/plus-badge.png'), 'Alchemy\Zippy\Resource\Teleporter\GenericTeleporter'),
         );
     }
 
     private function createResource($data)
     {
-        $resource = $this->getMockBuilder('Alchemy\Zippy\Resource\Resource')
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Resource\Resource')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -59,7 +59,7 @@ class TeleporterContainerTest extends TestCase
 
         $this->assertInstanceOf('Alchemy\Zippy\Resource\TeleporterContainer', $container);
 
-        $this->assertInstanceOf('Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter', $container['guzzle-teleporter']);
+        $this->assertInstanceOf('Alchemy\Zippy\Resource\Teleporter\GenericTeleporter', $container['guzzle-teleporter']);
         $this->assertInstanceOf('Alchemy\Zippy\Resource\Teleporter\StreamTeleporter', $container['stream-teleporter']);
         $this->assertInstanceOf('Alchemy\Zippy\Resource\Teleporter\LocalTeleporter', $container['local-teleporter']);
     }

--- a/tests/Tests/TestCase.php
+++ b/tests/Tests/TestCase.php
@@ -30,7 +30,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $collection = new ResourceCollection($context, $elements, false);
 
         $manager = $this
-            ->getMockBuilder('Alchemy\Zippy\Resource\ResourceManager')
+            ->getMockBuilder('\Alchemy\Zippy\Resource\ResourceManager')
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -43,7 +43,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getResource($data = null)
     {
-        $resource = $this->getMock('Alchemy\Zippy\Adapter\Resource\ResourceInterface');
+        $resource = $this->getMockBuilder('\Alchemy\Zippy\Adapter\Resource\ResourceInterface')->getMock();
 
         if (null !== $data) {
             $resource->expects($this->any())
@@ -60,7 +60,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             $this->fail('Trying to set a probe on an adapter that does not support it');
         }
 
-        $probe = $this->getMock('Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface');
+        $probe = $this->getMockBuilder('\Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface')->getMock();
         $probe->expects($this->any())
             ->method('getStatus')
             ->will($this->returnValue(VersionProbeInterface::PROBE_OK));
@@ -74,7 +74,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
             $this->fail('Trying to set a probe on an adapter that does not support it');
         }
 
-        $probe = $this->getMock('Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface');
+        $probe = $this->getMockBuilder('\Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface')->getMock();
         $probe->expects($this->any())
             ->method('getStatus')
             ->will($this->returnValue(VersionProbeInterface::PROBE_NOTSUPPORTED));
@@ -84,7 +84,8 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
 
     protected function getMockedProcessBuilderFactory($mockedProcessBuilder, $creations = 1)
     {
-        $mockedProcessBuilderFactory = $this->getMock('Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface');
+        $mockedProcessBuilderFactory =
+            $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface')->getMock();
 
         $mockedProcessBuilderFactory
             ->expects($this->exactly($creations))
@@ -97,7 +98,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
     protected function getSuccessFullMockProcess($runs = 1)
     {
         $mockProcess = $this
-            ->getMockBuilder('Symfony\Component\Process\Process')
+            ->getMockBuilder('\Symfony\Component\Process\Process')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Tests/ZippyTest.php
+++ b/tests/Tests/ZippyTest.php
@@ -220,7 +220,7 @@ class ZippyTest extends TestCase
 
     private function getStrategy($extension, $adapters)
     {
-        $strategy = $this->getMock('Alchemy\Zippy\FileStrategy\FileStrategyInterface');
+        $strategy = $this->getMockBuilder('\Alchemy\Zippy\FileStrategy\FileStrategyInterface')->getMock();
 
         $strategy->expects($this->any())
             ->method('getFileExtension')
@@ -235,7 +235,7 @@ class ZippyTest extends TestCase
 
     private function getSupportedAdapter()
     {
-        $adapter = $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
         $adapter->expects($this->any())
             ->method('isSupported')
             ->will($this->returnValue(true));
@@ -245,7 +245,7 @@ class ZippyTest extends TestCase
 
     private function getNotSupportedAdapter()
     {
-        $adapter = $this->getMock('Alchemy\Zippy\Adapter\AdapterInterface');
+        $adapter = $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
         $adapter->expects($this->any())
             ->method('isSupported')
             ->will($this->returnValue(false));
@@ -255,6 +255,6 @@ class ZippyTest extends TestCase
 
     private function getContainer()
     {
-        return $this->getMock('Alchemy\Zippy\Adapter\AdapterContainer');
+        return $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterContainer')->getMock();
     }
 }


### PR DESCRIPTION
- Remove usage of deprecated test method `getMock`
- Use generic teleporter instead of Guzzle specific teleporter
- Deprecate static method `create` on teleporters
- Deprecate class `\Alchemy\Zippy\Resource\Teleporter\GuzzleTeleporter`
- Deprecate class `\Alchemy\Zippy\Resource\Teleporter\LegacyGuzzleTeleporter`
- Deprecate class `\Alchemy\Zippy\Resource\Teleporter\AbstractTeleporter`