### PR TITLE
Fix Writers could not handle targets with sub-directories

### DIFF
--- a/src/Resource/Writer/FilesystemWriter.php
+++ b/src/Resource/Writer/FilesystemWriter.php
@@ -7,13 +7,17 @@ use Alchemy\Zippy\Resource\ResourceWriter;
 
 class FilesystemWriter implements ResourceWriter
 {
-
     /**
      * @param ResourceReader $reader
      * @param string $target
      */
     public function writeFromReader(ResourceReader $reader, $target)
     {
+        $directory = dirname($target);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
         file_put_contents($target, $reader->getContentsAsStream());
     }
 }

--- a/src/Resource/Writer/StreamWriter.php
+++ b/src/Resource/Writer/StreamWriter.php
@@ -13,6 +13,11 @@ class StreamWriter implements ResourceWriter
      */
     public function writeFromReader(ResourceReader $reader, $target)
     {
+        $directory = dirname($target);
+        if (!is_dir($directory)) {
+            mkdir($directory, 0777, true);
+        }
+
         $targetResource = fopen($target, 'w+');
         $sourceResource = $reader->getContentsAsStream();
 

--- a/tests/Tests/Resource/FilesystemWriterTest.php
+++ b/tests/Tests/Resource/FilesystemWriterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Alchemy\Zippy\Tests\Resource;
+
+use Alchemy\Zippy\Resource\Reader\Stream\StreamReader;
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Writer\FilesystemWriter;
+use Alchemy\Zippy\Tests\TestCase;
+
+class FilesystemWriterTest extends TestCase
+{
+    public function testWriteFromReader()
+    {
+        $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
+        $reader = new StreamReader($resource);
+
+        $streamWriter = new FilesystemWriter();
+        
+        $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/stream/writer/test.php');
+        $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/test.php');
+    }
+}

--- a/tests/Tests/Resource/StreamWriterTest.php
+++ b/tests/Tests/Resource/StreamWriterTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Alchemy\Zippy\Tests\Resource;
+
+use Alchemy\Zippy\Resource\Reader\Stream\StreamReader;
+use Alchemy\Zippy\Resource\Resource;
+use Alchemy\Zippy\Resource\Writer\StreamWriter;
+use Alchemy\Zippy\Tests\TestCase;
+
+class StreamWriterTest extends TestCase
+{
+    public function testWriteFromReader()
+    {
+        $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
+        $reader = new StreamReader($resource);
+
+        $streamWriter = new StreamWriter();
+
+        $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/stream/writer/test.php');
+        $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/test.php');
+    }
+}


### PR DESCRIPTION
If the target of a zip is a subdirectory, I got 'failed to open stream: No such file or directory' errors. Fix: Create directories before trying to open the file with fopen.