### PR TITLE
Remove overwrite-dir option from GNU Tar invocation

### DIFF
--- a/src/Adapter/GNUTar/TarGNUTarAdapter.php
+++ b/src/Adapter/GNUTar/TarGNUTarAdapter.php
@@ -66,7 +66,7 @@ class TarGNUTarAdapter extends AbstractTarAdapter
      */
     protected function getExtractOptions()
     {
-        return array('--overwrite-dir', '--overwrite');
+        return array('--overwrite');
     }
 
     /**
@@ -74,6 +74,6 @@ class TarGNUTarAdapter extends AbstractTarAdapter
      */
     protected function getExtractMembersOptions()
     {
-        return array('--overwrite-dir', '--overwrite');
+        return array('--overwrite');
     }
 }

--- a/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
@@ -271,12 +271,6 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
-            ->will($this->returnSelf());
-
-        $mockedProcessBuilder
-            ->expects($this->at(3))
-            ->method('add')
             ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
@@ -319,35 +313,29 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
+            ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
             ->method('add')
-            ->with($this->equalTo('--overwrite'))
+            ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(5))
             ->method('add')
-            ->with($this->equalTo($this->getOptions()))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(6))
             ->method('add')
-            ->with($this->equalTo('--directory'))
-            ->will($this->returnSelf());
-
-        $mockedProcessBuilder
-            ->expects($this->at(7))
-            ->method('add')
             ->with($this->equalTo(__DIR__))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
-            ->expects($this->at(8))
+            ->expects($this->at(7))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());

--- a/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
+++ b/tests/Tests/Adapter/GNUTar/TarGNUTarAdapterTest.php
@@ -270,12 +270,6 @@ class TarGNUTarAdapterTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(2))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
-            ->will($this->returnSelf());
-
-        $mockedProcessBuilder
-            ->expects($this->at(3))
-            ->method('add')
             ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
@@ -318,29 +312,23 @@ class TarGNUTarAdapterTest extends AdapterTestCase
         $mockedProcessBuilder
             ->expects($this->at(3))
             ->method('add')
-            ->with($this->equalTo('--overwrite-dir'))
+            ->with($this->equalTo('--overwrite'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(4))
             ->method('add')
-            ->with($this->equalTo('--overwrite'))
+            ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
             ->expects($this->at(5))
             ->method('add')
-            ->with($this->equalTo('--directory'))
-            ->will($this->returnSelf());
-
-        $mockedProcessBuilder
-            ->expects($this->at(6))
-            ->method('add')
             ->with($this->equalTo(__DIR__))
             ->will($this->returnSelf());
 
         $mockedProcessBuilder
-            ->expects($this->at(7))
+            ->expects($this->at(6))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());


### PR DESCRIPTION
This option never actually had any impact, as mentionned
in the following thread:
https://lists.gnu.org/archive/html/bug-tar/2016-05/msg00016.html

Fixes #114 