### PR TITLE
Optional parameter to allow manual definition of zip type.

### DIFF
--- a/src/Zippy.php
+++ b/src/Zippy.php
@@ -82,7 +82,7 @@ class Zippy
      */
     public function open($path, $type = null)
     {
-        if($type == null){
+        if (null === $type) {
             $type = $this->guessAdapterExtension($path);
         }
 

--- a/src/Zippy.php
+++ b/src/Zippy.php
@@ -80,9 +80,11 @@ class Zippy
      *
      * @throws RuntimeException In case of failure
      */
-    public function open($path)
+    public function open($path, $type = null)
     {
-        $type = $this->guessAdapterExtension($path);
+        if($type == null){
+            $type = $this->guessAdapterExtension($path);
+        }
 
         try {
             return $this


### PR DESCRIPTION
This allows users of the open function to manually define the zip type (which is useful for when files do not have the correct extension). This allows zips that have been uploaded by php (which depending on the platform will have no extension or a .tmp extension) to be extracted directly.