### PR TITLE
Fix date parsing on Centos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # CHANGELOG
 
 ## [Unreleased]
-- No unreleased changes
+- #111, #115: Parsing Zip archive dates failed on CentOS
 
 ## [0.4.4] - 2016-11-03
 ### Added
-- #115: Add an option to override archive type detection in `Zippy::open`, similar to `Zippy::create`, courtesy of @GiantCowFilms
+- #116: Add an option to override archive type detection in `Zippy::open`, similar to `Zippy::create`, courtesy of @GiantCowFilms
 
 ## [0.4.3] - 2016-11-03
 ### Fixed

--- a/src/Parser/ZipOutputParser.php
+++ b/src/Parser/ZipOutputParser.php
@@ -60,10 +60,17 @@ class ZipOutputParser implements ParserInterface
                 continue;
             }
 
+            $mtime = \DateTime::createFromFormat($this->dateFormat, $chunks[2]);
+
+            if ($mtime === false) {
+                // See https://github.com/alchemy-fr/Zippy/issues/111#issuecomment-251668427
+                $mtime = \DateTime::createFromFormat('H:i Y-m-d', $chunks[2]);
+            }
+
             $members[] = array(
                 'location'  => $chunks[3],
                 'size'      => $chunks[1],
-                'mtime'     => \DateTime::createFromFormat($this->dateFormat, $chunks[2]),
+                'mtime'     => $mtime,
                 'is_dir'    => '/' === substr($chunks[3], -1)
             );
         }


### PR DESCRIPTION
## Changelog
### Fixed
- #111 #115: Parsing Zip archive dates failed on CentOS