### PR TITLE
Fix relative location bug

### DIFF
--- a/src/Archive/Member.php
+++ b/src/Archive/Member.php
@@ -134,7 +134,7 @@ class Member implements MemberInterface
     {
         $this->adapter->extractMembers($this->resource, $this->location, $to, (bool) $overwrite);
 
-        return new \SplFileInfo(sprintf('%s%s', rtrim(null === $to ? getcwd() : $to, '/'), $this->location));
+        return new \SplFileInfo(sprintf('%s/%s', rtrim(null === $to ? getcwd() : $to, '/'), ltrim($this->location, '/')));
     }
 
     /**

--- a/tests/Tests/Archive/MemberTest.php
+++ b/tests/Tests/Archive/MemberTest.php
@@ -87,4 +87,28 @@ class MemberTest extends TestCase
         $file = $member->extract('/custom/location');
         $this->assertEquals('/custom/location/member/located/here', $file->getPathname());
     }
+
+    public function testRelativeExtract()
+    {
+        $mockAdapter =  $this->getMockBuilder('\Alchemy\Zippy\Adapter\AdapterInterface')->getMock();
+
+        $mockAdapter
+            ->expects($this->any())
+            ->method('extractMembers');
+
+        $member = new Member(
+           $this->getResource('archive/located/here'),
+           $mockAdapter,
+           'relative',
+           1233456,
+           new \DateTime("2012-07-08 11:14:15"),
+           true
+        );
+
+        $file = $member->extract();
+        $this->assertEquals(sprintf('%s%s', getcwd(), '/relative'), $file->getPathname());
+
+        $file = $member->extract('/custom/location');
+        $this->assertEquals('/custom/location/relative', $file->getPathname());
+    }
 }


### PR DESCRIPTION
When the member location is relative the resulting SplFileInfo instance
doesn't have the correct path. It ends up missing a joining `/` between the path and location.

Example debug of a member I have in my project:

```
array:1 [
  0 => Alchemy\Zippy\Archive\Member {#597
    -location: "example.csv"
  ...
]
```