### PR TITLE
Allow Symfony 4.0 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,16 +14,16 @@
     "require": {
         "php": ">=5.5",
         "doctrine/collections": "~1.0",
-        "symfony/filesystem": "^2.0.5|^3.0",
-        "symfony/process": "^2.1|^3.0",
+        "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0",
+        "symfony/process": "^2.1 || ^3.0 || ^4.0",
         "symfony/polyfill-mbstring": "^1.3"
     },
     "require-dev": {
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
         "guzzlehttp/guzzle": "^6.0",
-        "phpunit/phpunit": "^4.0|^5.0",
-        "symfony/finder": "^2.0.5|^3.0"
+        "phpunit/phpunit": "^4.0 || ^5.0",
+        "symfony/finder": "^2.0.5 || ^3.0 || ^4.0"
     },
     "suggest": {
         "ext-zip": "To use the ZipExtensionAdapter",


### PR DESCRIPTION
This PR allows Symfony 4.0 on composer.json in preparation for the Symfony 4.0 release on Nov 30 2017: http://symfony.com/blog/helping-prepare-for-symfony-4-bundle-support

#SymfonyConHackday2017