### PR TITLE
Replaces deprecated ProcessBuilder with lightly wrapped Symfony 4 Process

### DIFF
--- a/src/Adapter/AbstractBinaryAdapter.php
+++ b/src/Adapter/AbstractBinaryAdapter.php
@@ -20,6 +20,7 @@ use Alchemy\Zippy\Parser\ParserFactory;
 use Alchemy\Zippy\Parser\ParserInterface;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory;
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
+use Alchemy\Zippy\ProcessBuilder\ZippyProcess;
 use Alchemy\Zippy\Resource\ResourceManager;
 use Symfony\Component\Process\ExecutableFinder;
 use Symfony\Component\Process\ProcessBuilder;
@@ -199,16 +200,16 @@ abstract class AbstractBinaryAdapter extends AbstractAdapter implements BinaryAd
      * Adds files to argument list
      *
      * @param MemberInterface[]|\SplFileInfo[]|string[] $files   An array of files
-     * @param ProcessBuilder                            $builder A Builder instance
+     * @param ZippyProcess                            $process A ZippyProcess instance
      *
      * @return bool
      */
-    protected function addBuilderFileArgument(array $files, ProcessBuilder $builder)
+    protected function addBuilderFileArgument(array $files, ZippyProcess $process)
     {
         $iterations = 0;
 
-        array_walk($files, function($file) use ($builder, &$iterations) {
-            $builder->add(
+        array_walk($files, function($file) use ($process, &$iterations) {
+            $process->add(
                 $file instanceof \SplFileInfo ?
                     $file->getRealPath() : ($file instanceof MemberInterface ? $file->getLocation() : $file)
             );

--- a/src/Adapter/AbstractTarAdapter.php
+++ b/src/Adapter/AbstractTarAdapter.php
@@ -77,8 +77,7 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
         $process = $this
             ->inflator
             ->create()
-            ->add('--version')
-            ->getProcess();
+            ->add('--version');
 
         $process->run();
 
@@ -104,48 +103,45 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
         if (!$recursive) {
-            $builder->add('--no-recursion');
+            $process->add('--no-recursion');
         }
 
-        $builder->add('-c');
+        $process->add('-c');
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
         if (0 === count($files)) {
             $nullFile = defined('PHP_WINDOWS_VERSION_BUILD') ? 'NUL' : '/dev/null';
 
-            $builder->add('-f');
-            $builder->add($path);
-            $builder->add('-T');
-            $builder->add($nullFile);
+            $process->add('-f');
+            $process->add($path);
+            $process->add('-T');
+            $process->add($nullFile);
 
-            $process = $builder->getProcess();
             $process->run();
 
         } else {
 
-            $builder->add(sprintf('--file=%s', $path));
+            $process->add(sprintf('--file=%s', $path));
 
             if (!$recursive) {
-                $builder->add('--no-recursion');
+                $process->add('--no-recursion');
             }
 
             $collection = $this->manager->handle(getcwd(), $files);
 
-            $builder->setWorkingDirectory($collection->getContext());
+            $process->setWorkingDirectory($collection->getContext());
 
-            $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
-                return $builder->add($resource->getTarget());
+            $collection->forAll(function($i, ZippyResource $resource) use ($process) {
+                return $process->add($resource->getTarget());
             });
-
-            $process = $builder->getProcess();
 
             try {
                 $process->run();
@@ -170,24 +166,23 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
     protected function doTarListMembers($options, ResourceInterface $resource)
     {
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
         foreach ($this->getListMembersOptions() as $option) {
-            $builder->add($option);
+            $process->add($option);
         }
 
-        $builder
+        $process
             ->add('--list')
             ->add('-v')
             ->add(sprintf('--file=%s', $resource->getResource()));
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
-        $process = $builder->getProcess();
         $process->run();
 
         if (!$process->isSuccessful()) {
@@ -218,33 +213,31 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
         if (!$recursive) {
-            $builder->add('--no-recursion');
+            $process->add('--no-recursion');
         }
 
-        $builder
+        $process
             ->add('--append')
             ->add(sprintf('--file=%s', $resource->getResource()));
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
         // there will be an issue if the file starts with a dash
         // see --add-file=FILE
         $collection = $this->manager->handle(getcwd(), $files);
 
-        $builder->setWorkingDirectory($collection->getContext());
+        $process->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
-            return $builder->add($resource->getTarget());
+        $collection->forAll(function($i, ZippyResource $resource) use ($process) {
+            return $process->add($resource->getTarget());
         });
-
-        $process = $builder->getProcess();
 
         try {
             $process->run();
@@ -270,23 +263,21 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
-        $builder
+        $process
             ->add('--delete')
             ->add(sprintf('--file=%s', $resource->getResource()));
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
-        if (!$this->addBuilderFileArgument($files, $builder)) {
+        if (!$this->addBuilderFileArgument($files, $process)) {
             throw new InvalidArgumentException('Invalid files');
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 
@@ -307,30 +298,28 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
             throw new InvalidArgumentException(sprintf("%s is not a directory", $to));
         }
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
-        $builder
+        $process
             ->add('--extract')
             ->add(sprintf('--file=%s', $resource->getResource()));
 
         foreach ($this->getExtractOptions() as $option) {
-            $builder
+            $process
                 ->add($option);
         }
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
         if (null !== $to) {
-            $builder
+            $process
                 ->add('--directory')
                 ->add($to);
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 
@@ -362,38 +351,36 @@ abstract class AbstractTarAdapter extends AbstractBinaryAdapter
 
         $members = (array) $members;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
         if ($overwrite == false) {
-            $builder->add('-k');
+            $process->add('-k');
         }
 
-        $builder
+        $process
             ->add('--extract')
             ->add(sprintf('--file=%s', $resource->getResource()));
 
         foreach ($this->getExtractMembersOptions() as $option) {
-            $builder
+            $process
                 ->add($option);
         }
 
         foreach ((array) $options as $option) {
-            $builder->add((string) $option);
+            $process->add((string) $option);
         }
 
         if (null !== $to) {
-            $builder
+            $process
                 ->add('--directory')
                 ->add($to);
         }
 
-        if (!$this->addBuilderFileArgument($members, $builder)) {
+        if (!$this->addBuilderFileArgument($members, $process)) {
             throw new InvalidArgumentException('Invalid files');
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 

--- a/src/Adapter/VersionProbe/AbstractTarVersionProbe.php
+++ b/src/Adapter/VersionProbe/AbstractTarVersionProbe.php
@@ -13,7 +13,7 @@
 namespace Alchemy\Zippy\Adapter\VersionProbe;
 
 use Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface;
-use Symfony\Component\Process\Process;
+use Alchemy\Zippy\ProcessBuilder\ZippyProcess;
 
 abstract class AbstractTarVersionProbe implements VersionProbeInterface
 {
@@ -43,11 +43,10 @@ abstract class AbstractTarVersionProbe implements VersionProbeInterface
         $good = true;
 
         foreach (array($this->inflator, $this->deflator) as $builder) {
-            /** @var Process $process */
+            /** @var ZippyProcess $process */
             $process = $builder
                 ->create()
-                ->add('--version')
-                ->getProcess();
+                ->add('--version');
 
             $process->run();
 

--- a/src/Adapter/VersionProbe/ZipVersionProbe.php
+++ b/src/Adapter/VersionProbe/ZipVersionProbe.php
@@ -68,16 +68,14 @@ class ZipVersionProbe implements VersionProbeInterface
         $processDeflate = $this
             ->deflator
             ->create()
-            ->add('-h')
-            ->getProcess();
+            ->add('-h');
 
         $processDeflate->run();
 
         $processInflate = $this
             ->inflator
             ->create()
-            ->add('-h')
-            ->getProcess();
+            ->add('-h');
 
         $processInflate->run();
 

--- a/src/Adapter/ZipAdapter.php
+++ b/src/Adapter/ZipAdapter.php
@@ -49,7 +49,7 @@ class ZipAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
@@ -58,19 +58,17 @@ class ZipAdapter extends AbstractBinaryAdapter
         }
 
         if ($recursive) {
-            $builder->add('-r');
+            $process->add('-r');
         }
 
-        $builder->add($path);
+        $process->add($path);
 
         $collection = $this->manager->handle(getcwd(), $files);
-        $builder->setWorkingDirectory($collection->getContext());
+        $process->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
-            return $builder->add($resource->getTarget());
+        $collection->forAll(function($i, ZippyResource $resource) use ($process) {
+            return $process->add($resource->getTarget());
         });
-
-        $process = $builder->getProcess();
 
         try {
             $process->run();
@@ -101,8 +99,7 @@ class ZipAdapter extends AbstractBinaryAdapter
             ->deflator
             ->create()
             ->add('-l')
-            ->add($resource->getResource())
-            ->getProcess();
+            ->add($resource->getResource());
 
         $process->run();
 
@@ -137,27 +134,25 @@ class ZipAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
         if ($recursive) {
-            $builder->add('-r');
+            $process->add('-r');
         }
 
-        $builder
+        $process
             ->add('-u')
             ->add($resource->getResource());
 
         $collection = $this->manager->handle(getcwd(), $files);
 
-        $builder->setWorkingDirectory($collection->getContext());
+        $process->setWorkingDirectory($collection->getContext());
 
-        $collection->forAll(function($i, ZippyResource $resource) use ($builder) {
-            return $builder->add($resource->getTarget());
+        $collection->forAll(function($i, ZippyResource $resource) use ($process) {
+            return $process->add($resource->getTarget());
         });
-
-        $process = $builder->getProcess();
 
         try {
             $process->run();
@@ -185,8 +180,7 @@ class ZipAdapter extends AbstractBinaryAdapter
         $process = $this
             ->deflator
             ->create()
-            ->add('-h')
-            ->getProcess();
+            ->add('-h');
 
         $process->run();
 
@@ -209,8 +203,7 @@ class ZipAdapter extends AbstractBinaryAdapter
         $process = $this
             ->inflator
             ->create()
-            ->add('-h')
-            ->getProcess();
+            ->add('-h');
 
         $process->run();
 
@@ -232,19 +225,17 @@ class ZipAdapter extends AbstractBinaryAdapter
     {
         $files = (array) $files;
 
-        $builder = $this
+        $process = $this
             ->inflator
             ->create();
 
-        $builder
+        $process
             ->add('-d')
             ->add($resource->getResource());
 
-        if (!$this->addBuilderFileArgument($files, $builder)) {
+        if (!$this->addBuilderFileArgument($files, $process)) {
             throw new InvalidArgumentException('Invalid files');
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 
@@ -292,21 +283,19 @@ class ZipAdapter extends AbstractBinaryAdapter
             throw new InvalidArgumentException(sprintf("%s is not a directory", $to));
         }
 
-        $builder = $this
+        $process = $this
             ->deflator
             ->create();
 
-        $builder
+        $process
             ->add('-o')
             ->add($resource->getResource());
 
         if (null !== $to) {
-            $builder
+            $process
                 ->add('-d')
                 ->add($to);
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 
@@ -332,28 +321,26 @@ class ZipAdapter extends AbstractBinaryAdapter
 
         $members = (array) $members;
 
-        $builder = $this
+        $process = $this
             ->deflator
             ->create();
 
         if ((bool) $overwrite) {
-            $builder->add('-o');
+            $process->add('-o');
         }
 
-        $builder
+        $process
             ->add($resource->getResource());
 
         if (null !== $to) {
-            $builder
+            $process
                 ->add('-d')
                 ->add($to);
         }
 
-        if (!$this->addBuilderFileArgument($members, $builder)) {
+        if (!$this->addBuilderFileArgument($members, $process)) {
             throw new InvalidArgumentException('Invalid files');
         }
-
-        $process = $builder->getProcess();
 
         $process->run();
 

--- a/src/ProcessBuilder/ProcessBuilderFactory.php
+++ b/src/ProcessBuilder/ProcessBuilderFactory.php
@@ -12,7 +12,6 @@
 namespace Alchemy\Zippy\ProcessBuilder;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Symfony\Component\Process\ProcessBuilder;
 
 class ProcessBuilderFactory implements ProcessBuilderFactoryInterface
 {
@@ -66,6 +65,8 @@ class ProcessBuilderFactory implements ProcessBuilderFactoryInterface
             throw new InvalidArgumentException('No binary set');
         }
 
-        return ProcessBuilder::create(array($this->binary))->setTimeout(null);
+        $process = new ZippyProcess(array($this->binary));
+        $process->setTimeout(null);
+        return $process;
     }
 }

--- a/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
+++ b/src/ProcessBuilder/ProcessBuilderFactoryInterface.php
@@ -12,14 +12,13 @@
 namespace Alchemy\Zippy\ProcessBuilder;
 
 use Alchemy\Zippy\Exception\InvalidArgumentException;
-use Symfony\Component\Process\ProcessBuilder;
 
 interface ProcessBuilderFactoryInterface
 {
     /**
-     * Returns a new instance of Symfony ProcessBuilder
+     * Returns a new instance of Symfony Process
      *
-     * @return ProcessBuilder
+     * @return ZippyProcess
      *
      * @throws InvalidArgumentException
      */

--- a/src/ProcessBuilder/ZippyProcess.php
+++ b/src/ProcessBuilder/ZippyProcess.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Alchemy\Zippy\ProcessBuilder;
+
+use Symfony\Component\Process\Process;
+
+class ZippyProcess extends Process
+{
+    /**
+     * @param string $argument The argument to append to the commandline string
+     * @return $this
+     */
+    public function add($argument) {
+        $commandline = explode(' ', $this->getCommandLine());
+        $commandline[] = $argument;
+        $this->setCommandLine($commandline);
+        return $this;
+    }
+}

--- a/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
@@ -2,6 +2,8 @@
 
 namespace Alchemy\Zippy\Tests\Adapter\BSDTar;
 
+use Alchemy\Zippy\Adapter\AbstractAdapter;
+use Alchemy\Zippy\Adapter\AbstractTarAdapter;
 use Alchemy\Zippy\Tests\Adapter\AdapterTestCase;
 use Alchemy\Zippy\Parser\ParserFactory;
 
@@ -10,7 +12,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     protected static $tarFile;
 
     /**
-     * @var AbstractBSDTarAdapter
+     * @var AbstractAdapter|AbstractTarAdapter
      */
     protected $adapter;
 
@@ -41,9 +43,9 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
         $classname = static::getAdapterClassName();
 
         $inflator = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactory')
-                ->disableOriginalConstructor()
-                ->setMethods(array('useBinary'))
-                ->getMock();
+            ->disableOriginalConstructor()
+            ->setMethods(array('useBinary'))
+            ->getMock();
 
         $outputParser = ParserFactory::create($classname::getName());
 
@@ -90,27 +92,27 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
 
     public function testCreateNoFiles()
     {
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('-c'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo('-f'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(3))
             ->method('add')
             ->with($this->equalTo($this->getExpectedAbsolutePathForTarget(self::$tarFile)))
@@ -118,71 +120,62 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
 
         $nullFile = defined('PHP_WINDOWS_VERSION_BUILD') ? 'NUL' : '/dev/null';
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(4))
             ->method('add')
             ->with($this->equalTo('-T'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(5))
             ->method('add')
-            ->with($this->equalTo( $nullFile))
+            ->with($this->equalTo($nullFile))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $this->adapter->create(self::$tarFile, array());
     }
 
     public function testCreate()
     {
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('-c'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo(sprintf('--file=%s', $this->getExpectedAbsolutePathForTarget(self::$tarFile))))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(3))
             ->method('setWorkingDirectory')
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(4))
             ->method('add')
             ->with($this->equalTo('lalalalala'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
         $classname = static::getAdapterClassName();
         $outputParser = ParserFactory::create($classname::getName());
         $manager = $this->getResourceManagerMock(__DIR__, array('lalalalala'));
 
-        $this->adapter = new $classname($outputParser, $manager, $this->getMockedProcessBuilderFactory($mockedProcessBuilder), $this->getMockedProcessBuilderFactory($mockedProcessBuilder, 0));
+        $this->adapter = new $classname($outputParser, $manager, $this->getMockedProcessBuilderFactory($mockedProcess),
+            $this->getMockedProcessBuilderFactory($mockedProcess, 0));
         $this->setProbeIsOk($this->adapter);
 
         $this->adapter->create(self::$tarFile, array(__FILE__));
@@ -205,38 +198,33 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('--list'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo('-v'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo(sprintf('--file=%s', $resource->getResource())))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(3))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $this->adapter->listMembers($resource);
     }
@@ -244,26 +232,22 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     public function testAddFile()
     {
         $resource = $this->getResource(self::$tarFile);
-        $this->setExpectedException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
+        $this->setExpectedException('Alchemy\Zippy\Exception\NotSupportedException',
+            'Updating a compressed tar archive is not supported.');
         $this->adapter->add($resource, array(__DIR__ . '/../TestCase.php'));
     }
 
     public function testgetVersion()
     {
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('--version'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $this->adapter->getInflatorVersion();
     }
@@ -272,32 +256,27 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo(sprintf('--file=%s', $resource->getResource())))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $dir = $this->adapter->extract($resource);
         $pathinfo = pathinfo(self::$tarFile);
@@ -308,56 +287,51 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('-k'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo('--extract'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(3))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(4))
             ->method('add')
             ->with($this->equalTo('--directory'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(5))
             ->method('add')
             ->with($this->equalTo(__DIR__))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(6))
             ->method('add')
             ->with($this->equalTo(__FILE__))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
-
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $this->adapter->extractMembers($resource, array(__FILE__), __DIR__);
     }
@@ -366,42 +340,37 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     {
         $resource = $this->getResource(self::$tarFile);
 
-        $mockedProcessBuilder = $this->getMockBuilder('\Symfony\Component\Process\ProcessBuilder')->getMock();
+        $mockedProcess = $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ZippyProcess')->setConstructorArgs(array(array()))->getMock();
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(0))
             ->method('add')
             ->with($this->equalTo('--delete'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(1))
             ->method('add')
             ->with($this->equalTo('--file=' . $resource->getResource()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(2))
             ->method('add')
             ->with($this->equalTo($this->getOptions()))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(3))
             ->method('add')
             ->with($this->equalTo(__DIR__ . '/../TestCase.php'))
             ->will($this->returnSelf());
 
-        $mockedProcessBuilder
+        $mockedProcess
             ->expects($this->at(4))
             ->method('add')
             ->with($this->equalTo('path-to-file'))
             ->will($this->returnSelf());
-
-        $mockedProcessBuilder
-            ->expects($this->once())
-            ->method('getProcess')
-            ->will($this->returnValue($this->getSuccessFullMockProcess()));
 
         $archiveFileMock = $this->getMockBuilder('\Alchemy\Zippy\Archive\MemberInterface')->getMock();
         $archiveFileMock
@@ -409,11 +378,11 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
             ->method('getLocation')
             ->will($this->returnValue('path-to-file'));
 
-        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcessBuilder));
+        $this->adapter->setInflator($this->getMockedProcessBuilderFactory($mockedProcess));
 
         $this->adapter->remove($resource, array(
             __DIR__ . '/../TestCase.php',
-            $archiveFileMock
+            $archiveFileMock,
         ));
     }
 

--- a/tests/Tests/TestCase.php
+++ b/tests/Tests/TestCase.php
@@ -82,7 +82,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $adapter->setVersionProbe($probe);
     }
 
-    protected function getMockedProcessBuilderFactory($mockedProcessBuilder, $creations = 1)
+    protected function getMockedProcessBuilderFactory($mockedProcess, $creations = 1)
     {
         $mockedProcessBuilderFactory =
             $this->getMockBuilder('\Alchemy\Zippy\ProcessBuilder\ProcessBuilderFactoryInterface')->getMock();
@@ -90,7 +90,7 @@ abstract class TestCase extends \PHPUnit_Framework_TestCase
         $mockedProcessBuilderFactory
             ->expects($this->exactly($creations))
             ->method('create')
-            ->will($this->returnValue($mockedProcessBuilder));
+            ->will($this->returnValue($mockedProcess));
 
         return $mockedProcessBuilderFactory;
     }


### PR DESCRIPTION
@jygaulier Here's an alternative approach. I made a ZippyProcess class (extends Process) so the terse `add()` syntax could be preserved. I started fixing the test mocks but realised I had no idea what I was doing. If you guys like the way this is headed maybe you or someone else could help fixing the test suite.