### PR TITLE
Fix tests and allow Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 7.0
+    - php: 7.1
       env: PREFER_LOWEST="--prefer-lowest"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: php
 sudo: required
 
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
+  - 7.2
+  - 7.3
+  - 7.4
 
 env:
   PREFER_LOWEST=""
@@ -14,7 +15,7 @@ env:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
+    - php: 7.0
       env: PREFER_LOWEST="--prefer-lowest"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 sudo: required
 
 php:
-  - 7.0
   - 7.1
   - 7.2
   - 7.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased changes]
 - No changes
 
+## [0.4.10] - 2018-02-27
+### Changed
+- Allow Symfony 5.0 components
+- Drop support for PHP5 (it is long gone)
+
+## [0.4.9] - 2018-02-27
+### Changed
+- Allow Symfony 4.0 in composer.json
+
 ## [0.4.8] - 2017-03-03
 ### Fixed
 - #125: Fix invalid paths with relative locations, courtesy of @paulredmond

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased changes]
 - No changes
 
-## [0.4.10] - 2018-02-27
+## [0.4.10] - TBD
 ### Changed
 - Allow Symfony 5.0 components
 - Drop support for PHP5 (it is long gone)

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
     "require": {
         "php": ">=5.5",
         "doctrine/collections": "~1.0",
-        "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0",
-        "symfony/process": "^3.4 || ^4.0",
+        "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0 || ^5.0",
+        "symfony/process": "^3.4 || ^4.0 || ^5.0",
         "symfony/polyfill-mbstring": "^1.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.0",
         "doctrine/collections": "~1.0",
         "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0 || ^5.0",
         "symfony/process": "^3.4 || ^4.0 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
         "guzzlehttp/guzzle": "^6.0",
-        "phpunit/phpunit": "^4.0 || ^5.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/finder": "^2.0.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0",
+        "php": ">=7.1",
         "doctrine/collections": "~1.0",
         "symfony/filesystem": "^2.0.5 || ^3.0 || ^4.0 || ^5.0",
         "symfony/process": "^3.4 || ^4.0 || ^5.0",
@@ -22,7 +22,7 @@
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
         "guzzlehttp/guzzle": "^6.0",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.0",
         "symfony/finder": "^2.0.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "guzzle/guzzle": "~3.0",
         "guzzlehttp/guzzle": "^6.0",
         "phpunit/phpunit": "^4.0 || ^5.0",
-        "symfony/finder": "^2.0.5 || ^3.0 || ^4.0"
+        "symfony/finder": "^2.0.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {
         "ext-zip": "To use the ZipExtensionAdapter",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "ext-zip": "*",
         "guzzle/guzzle": "~3.0",
         "guzzlehttp/guzzle": "^6.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.0",
         "symfony/finder": "^2.0.5 || ^3.0 || ^4.0 || ^5.0"
     },
     "suggest": {

--- a/phpunit-functional.xml.dist
+++ b/phpunit-functional.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="false"
          bootstrap="vendor/autoload.php"
 >

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="true"
          verbose="false"
          bootstrap="vendor/autoload.php"
 >

--- a/tests/Functional/Add2ArchiveTest.php
+++ b/tests/Functional/Add2ArchiveTest.php
@@ -55,7 +55,7 @@ class Add2ArchiveTest extends FunctionalTestCase
             'Alchemy\Zippy\Adapter\BSDTar\TarGzBSDTarAdapter',
             'Alchemy\Zippy\Adapter\BSDTar\TarBz2BSDTarAdapter',
         ))) {
-            $this->setExpectedException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
+            $this->expectException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
         }
 
         $archive->addMembers(array('somemorefiles/nicephoto.jpg' => __DIR__ . '/samples/morefiles/morephoto.jpg'));

--- a/tests/Functional/CreateArchiveTest.php
+++ b/tests/Functional/CreateArchiveTest.php
@@ -18,9 +18,11 @@ class CreateArchiveTest extends FunctionalTestCase
         }
     }
 
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testCreate()
     {
-        self::expectNotToPerformAssertions();
         $adapter = $this->getAdapter();
         $extension = $this->getArchiveExtensionForAdapter($adapter);
 

--- a/tests/Functional/CreateArchiveTest.php
+++ b/tests/Functional/CreateArchiveTest.php
@@ -20,6 +20,7 @@ class CreateArchiveTest extends FunctionalTestCase
 
     public function testCreate()
     {
+        self::expectNotToPerformAssertions();
         $adapter = $this->getAdapter();
         $extension = $this->getArchiveExtensionForAdapter($adapter);
 

--- a/tests/Functional/ExtractArchiveTest.php
+++ b/tests/Functional/ExtractArchiveTest.php
@@ -6,10 +6,11 @@ use Symfony\Component\Finder\Finder;
 
 class ExtractArchiveTest extends FunctionalTestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testOpen()
     {
-        self::expectNotToPerformAssertions();
-
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Functional/ExtractArchiveTest.php
+++ b/tests/Functional/ExtractArchiveTest.php
@@ -8,6 +8,8 @@ class ExtractArchiveTest extends FunctionalTestCase
 {
     public function testOpen()
     {
+        self::expectNotToPerformAssertions();
+
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Functional/ExtractMembersArchiveTest.php
+++ b/tests/Functional/ExtractMembersArchiveTest.php
@@ -6,10 +6,11 @@ use Alchemy\Zippy\Archive\ArchiveInterface;
 
 class ExtractMembersArchiveTest extends FunctionalTestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testOpen()
     {
-        self::expectNotToPerformAssertions();
-
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Functional/ExtractMembersArchiveTest.php
+++ b/tests/Functional/ExtractMembersArchiveTest.php
@@ -8,6 +8,8 @@ class ExtractMembersArchiveTest extends FunctionalTestCase
 {
     public function testOpen()
     {
+        self::expectNotToPerformAssertions();
+
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Functional/FunctionalTestCase.php
+++ b/tests/Functional/FunctionalTestCase.php
@@ -6,7 +6,7 @@ use Alchemy\Zippy\Adapter\AdapterInterface;
 use Alchemy\Zippy\Adapter\AdapterContainer;
 use Symfony\Component\Filesystem\Filesystem;
 
-abstract class FunctionalTestCase extends \PHPUnit_Framework_TestCase
+abstract class FunctionalTestCase extends \PHPUnit\Framework\TestCase
 {
     public function tearDown()
     {

--- a/tests/Functional/ListArchiveTest.php
+++ b/tests/Functional/ListArchiveTest.php
@@ -4,10 +4,11 @@ namespace Alchemy\Zippy\Functional;
 
 class ListArchiveTest extends FunctionalTestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testOpen()
     {
-        self::expectNotToPerformAssertions();
-
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Functional/ListArchiveTest.php
+++ b/tests/Functional/ListArchiveTest.php
@@ -6,6 +6,8 @@ class ListArchiveTest extends FunctionalTestCase
 {
     public function testOpen()
     {
+        self::expectNotToPerformAssertions();
+
         $adapter = $this->getAdapter();
         $archiveFile = $this->getArchiveFileForAdapter($adapter);
 

--- a/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/BSDTar/BSDTarAdapterWithOptionsTest.php
@@ -250,7 +250,7 @@ abstract class BSDTarAdapterWithOptionsTest extends AdapterTestCase
     public function testAddFile()
     {
         $resource = $this->getResource(self::$tarFile);
-        $this->setExpectedException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
+        $this->expectException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
         $this->adapter->add($resource, array(__DIR__ . '/../TestCase.php'));
     }
 

--- a/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
+++ b/tests/Tests/Adapter/GNUTar/GNUTarAdapterWithOptionsTest.php
@@ -232,7 +232,7 @@ abstract class GNUTarAdapterWithOptionsTest extends AdapterTestCase
     public function testAddFile()
     {
         $resource = $this->getResource(self::$tarFile);
-        $this->setExpectedException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
+        $this->expectException('Alchemy\Zippy\Exception\NotSupportedException', 'Updating a compressed tar archive is not supported.');
         $this->adapter->add($resource, array(__DIR__ . '/../TestCase.php'));
     }
 

--- a/tests/Tests/Adapter/ZipExtensionAdapterTest.php
+++ b/tests/Tests/Adapter/ZipExtensionAdapterTest.php
@@ -4,6 +4,7 @@ namespace Alchemy\Zippy\Tests\Adapter;
 
 use Alchemy\Zippy\Adapter\ZipExtensionAdapter;
 use Alchemy\Zippy\Adapter\Resource\ZipArchiveResource;
+use Alchemy\Zippy\Exception\RuntimeException;
 
 class ZipExtensionAdapterTest extends AdapterTestCase
 {
@@ -60,12 +61,12 @@ class ZipExtensionAdapterTest extends AdapterTestCase
         unlink($file);
     }
 
-    /**
-     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
-     */
     public function testOpenWithWrongFileName()
     {
-        $file = __DIR__ . '/zip-file.zip';
+        $file = __DIR__ . '/zip-file-non-existing.zip';
+
+        self::expectException(RuntimeException::class);
+
         $this->adapter->open($file);
     }
 
@@ -193,7 +194,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException RuntimeException
      */
     public function testRemoveWithDeleteFailing()
     {
@@ -251,7 +252,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException RuntimeException
      */
     public function testAddFailOnFile()
     {
@@ -280,7 +281,7 @@ class ZipExtensionAdapterTest extends AdapterTestCase
     }
 
     /**
-     * @expectedException \Alchemy\Zippy\Exception\RuntimeException
+     * @expectedException RuntimeException
      */
     public function testAddFailOnDir()
     {

--- a/tests/Tests/Parser/BSDTarOutputParserTest.php
+++ b/tests/Tests/Parser/BSDTarOutputParserTest.php
@@ -7,9 +7,11 @@ use Alchemy\Zippy\Tests\TestCase;
 
 class BSDTarOutputParserTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testNewParser()
     {
-        self::expectNotToPerformAssertions();
         return new BSDTarOutputParser();
     }
 

--- a/tests/Tests/Parser/BSDTarOutputParserTest.php
+++ b/tests/Tests/Parser/BSDTarOutputParserTest.php
@@ -9,6 +9,7 @@ class BSDTarOutputParserTest extends TestCase
 {
     public function testNewParser()
     {
+        self::expectNotToPerformAssertions();
         return new BSDTarOutputParser();
     }
 

--- a/tests/Tests/Parser/GNUTarOutputParserTest.php
+++ b/tests/Tests/Parser/GNUTarOutputParserTest.php
@@ -7,9 +7,11 @@ use Alchemy\Zippy\Tests\TestCase;
 
 class GNUTarOutputParserTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testNewParser()
     {
-        self::expectNotToPerformAssertions();
         return new GNUTarOutputParser();
     }
 

--- a/tests/Tests/Parser/GNUTarOutputParserTest.php
+++ b/tests/Tests/Parser/GNUTarOutputParserTest.php
@@ -9,6 +9,7 @@ class GNUTarOutputParserTest extends TestCase
 {
     public function testNewParser()
     {
+        self::expectNotToPerformAssertions();
         return new GNUTarOutputParser();
     }
 

--- a/tests/Tests/Parser/ZipOutputParserTest.php
+++ b/tests/Tests/Parser/ZipOutputParserTest.php
@@ -9,6 +9,7 @@ class ZipOutputParserTest extends TestCase
 {
     public function testNewParser()
     {
+        self::expectNotToPerformAssertions();
         return new ZipOutputParser();
     }
 

--- a/tests/Tests/Parser/ZipOutputParserTest.php
+++ b/tests/Tests/Parser/ZipOutputParserTest.php
@@ -7,9 +7,11 @@ use Alchemy\Zippy\Tests\TestCase;
 
 class ZipOutputParserTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testNewParser()
     {
-        self::expectNotToPerformAssertions();
         return new ZipOutputParser();
     }
 

--- a/tests/Tests/Resource/FilesystemWriterTest.php
+++ b/tests/Tests/Resource/FilesystemWriterTest.php
@@ -9,9 +9,11 @@ use Alchemy\Zippy\Tests\TestCase;
 
 class FilesystemWriterTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWriteFromReader()
     {
-        self::expectNotToPerformAssertions();
         $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
         $reader = new StreamReader($resource);
 

--- a/tests/Tests/Resource/FilesystemWriterTest.php
+++ b/tests/Tests/Resource/FilesystemWriterTest.php
@@ -11,11 +11,12 @@ class FilesystemWriterTest extends TestCase
 {
     public function testWriteFromReader()
     {
+        self::expectNotToPerformAssertions();
         $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
         $reader = new StreamReader($resource);
 
         $streamWriter = new FilesystemWriter();
-        
+
         $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/stream/writer/test.php');
         $streamWriter->writeFromReader($reader, sys_get_temp_dir().'/test.php');
     }

--- a/tests/Tests/Resource/ResourceTeleporterTest.php
+++ b/tests/Tests/Resource/ResourceTeleporterTest.php
@@ -12,6 +12,7 @@ class ResourceTeleporterTest extends TestCase
      */
     public function testConstruct()
     {
+        self::expectNotToPerformAssertions();
         $container = $this->getMockBuilder('\Alchemy\Zippy\Resource\TeleporterContainer')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Tests/Resource/ResourceTeleporterTest.php
+++ b/tests/Tests/Resource/ResourceTeleporterTest.php
@@ -9,10 +9,10 @@ class ResourceTeleporterTest extends TestCase
 {
     /**
      * @covers Alchemy\Zippy\Resource\ResourceTeleporter::__construct
+     * @doesNotPerformAssertions
      */
     public function testConstruct()
     {
-        self::expectNotToPerformAssertions();
         $container = $this->getMockBuilder('\Alchemy\Zippy\Resource\TeleporterContainer')
             ->disableOriginalConstructor()
             ->getMock();

--- a/tests/Tests/Resource/StreamWriterTest.php
+++ b/tests/Tests/Resource/StreamWriterTest.php
@@ -11,6 +11,7 @@ class StreamWriterTest extends TestCase
 {
     public function testWriteFromReader()
     {
+        self::expectNotToPerformAssertions();
         $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
         $reader = new StreamReader($resource);
 

--- a/tests/Tests/Resource/StreamWriterTest.php
+++ b/tests/Tests/Resource/StreamWriterTest.php
@@ -9,9 +9,11 @@ use Alchemy\Zippy\Tests\TestCase;
 
 class StreamWriterTest extends TestCase
 {
+    /**
+     * @doesNotPerformAssertions
+     */
     public function testWriteFromReader()
     {
-        self::expectNotToPerformAssertions();
         $resource = new Resource(fopen(__FILE__, 'r'), fopen(__FILE__, 'r'));
         $reader = new StreamReader($resource);
 

--- a/tests/Tests/TestCase.php
+++ b/tests/Tests/TestCase.php
@@ -8,7 +8,7 @@ use Alchemy\Zippy\Resource\ResourceCollection;
 use Alchemy\Zippy\Resource\Resource;
 use Alchemy\Zippy\Adapter\VersionProbe\VersionProbeInterface;
 
-abstract class TestCase extends \PHPUnit_Framework_TestCase
+abstract class TestCase extends \PHPUnit\Framework\TestCase
 {
     public static function getResourcesPath()
     {

--- a/tests/Tests/ZippyTest.php
+++ b/tests/Tests/ZippyTest.php
@@ -177,12 +177,10 @@ class ZippyTest extends TestCase
         $zippy = new Zippy($this->getContainer());
         $zippy->addStrategy($strategy);
 
-        try {
-            $zippy->getAdapterFor('zippo');
-            $this->fail('Should have raised an exception');
-        } catch (NoAdapterOnPlatformException $e) {
+        self::expectException(NoAdapterOnPlatformException::class);
+        $zippy->getAdapterFor('zippo');
 
-        }
+        $this->fail('Should have raised an exception');
     }
 
     /** @test */
@@ -194,12 +192,10 @@ class ZippyTest extends TestCase
         $zippy = new Zippy($this->getContainer());
         $zippy->addStrategy($strategy);
 
-        try {
-            $zippy->getAdapterFor('zippo');
-            $this->fail('Should have raised an exception');
-        } catch (FormatNotSupportedException $e) {
+        self::expectException(FormatNotSupportedException::class);
+        $zippy->getAdapterFor('zippo');
 
-        }
+        $this->fail('Should have raised an exception');
     }
 
     /** @test */


### PR DESCRIPTION
In this PR you'll find:

* Support for Symfony 5 components
* Drop support for PHP 5, PHP >= 7.1 
* Use PHPUnit 6 only, because alternative PHPUnit version in dev dependencies are not needed

Basically included: https://github.com/alchemy-fr/Zippy/pull/154